### PR TITLE
유저 랭킹 전체 조회 API

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -2,7 +2,7 @@ name: orvit-server-dev
 
 on:
   push:
-    branches: [develop]
+    branches: [develop, feature/issue-12]
 
 jobs:
   ci:

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -46,6 +46,7 @@ WORKDIR /${app_dir_base}/${app_name}
 COPY --from=build /${app_dir_base}/${app_name}/node_modules ./node_modules
 COPY --from=build /${app_dir_base}/${app_name}/dist ./dist
 COPY --from=build /${app_dir_base}/${app_name}/package.json ./package.json
+COPY --from=build /${app_dir_base}/${app_name}/prisma ./prisma
 
 EXPOSE 3000
 CMD ["node", "-r", "newrelic", "dist/main"]

--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
       "^@common/(.*)$": "<rootDir>/common/$1",
       "^@prisma/(.*)$": "<rootDir>/prisma/$1",
       "^@sse-sample/(.*)$": "<rootDir>/sse-sample/$1",
-      "^@tiers/(.*)$": "<rootDir>/tiers/$1"
+      "^@tiers/(.*)$": "<rootDir>/tiers/$1",
+      "^@users/(.*)$": "<rootDir>/users/$1"
     },
     "coverageDirectory": "../coverage",
     "testEnvironment": "node"

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,13 +7,15 @@ import { AppService } from './app.service';
 import { PrismaModule } from '@prisma/prisma.module';
 import { SseSampleModule } from '@sse-sample/sse-sample.module';
 import { TiersModule } from '@tiers/tiers.module';
+import { UsersModule } from '@users/users.module';
+
 import { ErrorExceptionFilter } from '@common/filters/error-exception.filter';
 import { TypeExceptionFilter } from '@common/filters/type-exception.filter';
 import { HttpExceptionFilter } from '@common/filters/http-exception.filter';
 import { ValidationException } from '@common/exceptions/validation.exception';
 
 @Module({
-  imports: [PrismaModule, SseSampleModule, TiersModule],
+  imports: [PrismaModule, SseSampleModule, TiersModule, UsersModule],
   controllers: [AppController],
   providers: [
     AppService,

--- a/src/games/presentation/decorators/get-game-options-swagger.decorator.ts
+++ b/src/games/presentation/decorators/get-game-options-swagger.decorator.ts
@@ -6,19 +6,20 @@ import {
   ApiResponse,
   getSchemaPath,
 } from '@nestjs/swagger';
+
+import { ApiResponseDto } from '@common/dto/api-response.dto';
 import { GetGameOptionsResponseDto } from '../dto/get-game-options.dto';
 
 export function ApiGetGameOptions() {
   return applyDecorators(
     ApiOperation({ summary: '게임 옵션 조회 (카테고리, 난이도)' }),
-    ApiExtraModels(GetGameOptionsResponseDto),
+    ApiExtraModels(ApiResponseDto, GetGameOptionsResponseDto),
     ApiOkResponse({
       description: '게임 옵션 조회 성공',
       schema: {
         type: 'object',
+        $ref: getSchemaPath(ApiResponseDto),
         properties: {
-          statusCode: { type: 'number', example: 200 },
-          success: { type: 'boolean', example: true },
           data: { $ref: getSchemaPath(GetGameOptionsResponseDto) },
         },
       },

--- a/src/games/presentation/dto/get-game-options.dto.ts
+++ b/src/games/presentation/dto/get-game-options.dto.ts
@@ -1,4 +1,3 @@
-import { ApiResponseDto } from '@common/dto/api-response.dto';
 import { GameOptions } from '../../domain/game-options.entity';
 import { GameDifficultyMode } from '../../domain/game.business-rules';
 import { ApiProperty } from '@nestjs/swagger';
@@ -18,7 +17,7 @@ export class CategoryDto {
   name: string;
 }
 
-export class GetGameOptionsResponseDto extends ApiResponseDto {
+export class GetGameOptionsResponseDto {
   @ApiProperty({
     description: '게임 카테고리 목록',
     type: [CategoryDto],

--- a/src/users/application/users.service.spec.ts
+++ b/src/users/application/users.service.spec.ts
@@ -1,0 +1,113 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { Tier } from '@tiers/domain/tiers.entity';
+
+import { UsersService } from './users.service';
+
+import { IUsersRepository, USER_REPOSITORY } from '../domain/users.repository.interface';
+import { User } from '../domain/users.entity';
+
+function createMockTier(overrides: Partial<Tier> = {}): Tier {
+  return Tier.from({
+    id: 1,
+    name: 'bronze',
+    minScore: 0,
+    imageUrl: null,
+    iconUrl: null,
+    ...overrides,
+  });
+}
+
+function createMockUser(overrides: Partial<User> = {}): User {
+  return User.from({
+    id: 1n,
+    email: 'test@test.com',
+    nickname: 'testUser',
+    provider: 'github',
+    providerId: '12345',
+    totalScore: 0n,
+    refreshToken: 'token',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    githubUrl: null,
+    profileImage: null,
+    tierId: null,
+    tier: null,
+    ...overrides,
+  });
+}
+
+describe('UsersService', () => {
+  let service: UsersService;
+  let mockUsersRepository: jest.Mocked<IUsersRepository>;
+
+  beforeEach(async () => {
+    mockUsersRepository = {
+      findAllOrderByScoreDesc: jest.fn(),
+      countAll: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UsersService,
+        {
+          provide: USER_REPOSITORY,
+          useValue: mockUsersRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<UsersService>(UsersService);
+  });
+
+  describe('getRanksByPageAndSize', () => {
+    let mockUsers: User[];
+
+    beforeEach(() => {
+      mockUsers = [
+        createMockUser({ nickname: 'user1', totalScore: 100n, tier: createMockTier() }),
+        createMockUser({
+          nickname: 'user2',
+          totalScore: 94n,
+          tier: createMockTier({ name: 'silver' }),
+        }),
+      ];
+
+      mockUsersRepository.findAllOrderByScoreDesc.mockResolvedValue(mockUsers);
+      mockUsersRepository.countAll.mockResolvedValue(mockUsers.length);
+    });
+
+    it('파라미터 정보로 유저 목록 조회하는지 확인', async () => {
+      const page = 2;
+      const size = 10;
+
+      await service.getRanksByPageAndSize(page, size);
+
+      expect(mockUsersRepository.findAllOrderByScoreDesc).toHaveBeenCalledWith(
+        page,
+        size,
+        undefined,
+      );
+    });
+
+    it('파라미터 정보로 전체 개수 조회하는지 확인', async () => {
+      const page = 2;
+      const size = 10;
+      const tierId = 1;
+
+      await service.getRanksByPageAndSize(page, size, tierId);
+
+      expect(mockUsersRepository.countAll).toHaveBeenCalledWith(tierId);
+    });
+
+    it('유저 목록과 개수 정보를 튜플로 반환하는지 확인', async () => {
+      const page = 2;
+      const size = 10;
+      const tierId = 1;
+
+      const ret = await service.getRanksByPageAndSize(page, size, tierId);
+
+      expect(ret).toEqual([mockUsers, mockUsers.length]);
+    });
+  });
+});

--- a/src/users/application/users.service.ts
+++ b/src/users/application/users.service.ts
@@ -1,0 +1,20 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import { IUsersRepository, USER_REPOSITORY } from '../domain/users.repository.interface';
+import { User } from '../domain/users.entity';
+
+@Injectable()
+export class UsersService {
+  constructor(@Inject(USER_REPOSITORY) private readonly usersRepository: IUsersRepository) {}
+
+  async getRanksByPageAndSize(
+    page: number,
+    size: number,
+    tierId?: number,
+  ): Promise<[User[], number]> {
+    return Promise.all([
+      this.usersRepository.findAllOrderByScoreDesc(page, size, tierId),
+      this.usersRepository.countAll(tierId),
+    ]);
+  }
+}

--- a/src/users/domain/users.entity.ts
+++ b/src/users/domain/users.entity.ts
@@ -1,0 +1,54 @@
+import { Tier } from '@tiers/domain/tiers.entity';
+
+export class User {
+  constructor(
+    public readonly id: bigint,
+    public readonly email: string,
+    public readonly nickname: string,
+    public readonly provider: string,
+    public readonly providerId: string,
+    public readonly totalScore: bigint,
+    public readonly refreshToken: string,
+    public readonly createdAt: Date,
+    public readonly updatedAt: Date,
+    public readonly githubUrl: string | null,
+    public readonly profileImage: string | null,
+    public readonly tierId: number | null,
+    public readonly tier: Tier | null,
+  ) {}
+
+  static from(
+    data: Pick<
+      User,
+      | 'id'
+      | 'email'
+      | 'nickname'
+      | 'provider'
+      | 'providerId'
+      | 'totalScore'
+      | 'refreshToken'
+      | 'createdAt'
+      | 'updatedAt'
+      | 'githubUrl'
+      | 'profileImage'
+      | 'tierId'
+      | 'tier'
+    >,
+  ): User {
+    return new User(
+      data.id,
+      data.email,
+      data.nickname,
+      data.provider,
+      data.providerId,
+      data.totalScore,
+      data.refreshToken,
+      data.createdAt,
+      data.updatedAt,
+      data.githubUrl,
+      data.profileImage,
+      data.tierId,
+      data.tier,
+    );
+  }
+}

--- a/src/users/domain/users.repository.interface.ts
+++ b/src/users/domain/users.repository.interface.ts
@@ -1,0 +1,8 @@
+import { User } from './users.entity';
+
+export interface IUsersRepository {
+  findAllOrderByScoreDesc(page: number, size: number, tierId?: number): Promise<User[]>;
+  countAll(tierId?: number): Promise<number>;
+}
+
+export const USER_REPOSITORY = Symbol('IUsersRepository');

--- a/src/users/infrastructure/users.repository.ts
+++ b/src/users/infrastructure/users.repository.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '@/prisma/prisma.service';
+
+import { IUsersRepository } from '../domain/users.repository.interface';
+import { User } from '../domain/users.entity';
+
+@Injectable()
+export class UsersRepositoryImpl implements IUsersRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAllOrderByScoreDesc(page: number, size: number, tierId?: number): Promise<User[]> {
+    const users = await this.prisma.user.findMany({
+      where: tierId ? { tierId } : {},
+      skip: (page - 1) * size,
+      take: size,
+      orderBy: { totalScore: 'desc' },
+      include: { tier: true },
+    });
+
+    return users.map((user) => User.from(user));
+  }
+
+  async countAll(tierId?: number): Promise<number> {
+    return this.prisma.user.count({ where: tierId ? { tierId } : {} });
+  }
+}

--- a/src/users/presentation/decorators/get-ranks-swagger.decorator.ts
+++ b/src/users/presentation/decorators/get-ranks-swagger.decorator.ts
@@ -1,0 +1,40 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiExtraModels,
+  ApiOkResponse,
+  ApiOperation,
+  ApiResponse,
+  getSchemaPath,
+} from '@nestjs/swagger';
+
+import { ApiResponseDto } from '@common/dto/api-response.dto';
+import { GetRanksResponseDto } from '../dto/get-ranks.dto';
+
+export function ApiGetRanks() {
+  return applyDecorators(
+    ApiOperation({ summary: '유저 전체, 티어별 랭킹 조회' }),
+    ApiExtraModels(ApiResponseDto, GetRanksResponseDto),
+    ApiOkResponse({
+      description: '유저 랭킹 전체 조회 성공',
+      schema: {
+        type: 'object',
+        $ref: getSchemaPath(ApiResponseDto),
+        properties: {
+          data: { $ref: getSchemaPath(GetRanksResponseDto) },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 400,
+      description: 'Validation Failed (e.g. Query string, Body, Params)',
+    }),
+    ApiResponse({
+      status: 500,
+      description: 'Internal Server Error',
+    }),
+    ApiResponse({
+      status: 503,
+      description: 'Service Unavailable',
+    }),
+  );
+}

--- a/src/users/presentation/dto/get-ranks.dto.ts
+++ b/src/users/presentation/dto/get-ranks.dto.ts
@@ -2,8 +2,6 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsInt, IsOptional, Min } from 'class-validator';
 import { plainToInstance, Type } from 'class-transformer';
 
-import { ApiResponseDto } from '@common/dto/api-response.dto';
-
 import { User } from '../../domain/users.entity';
 
 export class GetRanksQueryDto {
@@ -125,9 +123,4 @@ export class GetRanksResponseDto {
 
     return plainToInstance(GetRanksResponseDto, { ranks, metadata });
   }
-}
-
-export class RanksResponseDto extends ApiResponseDto {
-  @ApiProperty({ description: '랭킹 응답', type: GetRanksResponseDto })
-  data: GetRanksResponseDto;
 }

--- a/src/users/presentation/dto/get-ranks.dto.ts
+++ b/src/users/presentation/dto/get-ranks.dto.ts
@@ -1,0 +1,133 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsInt, IsOptional, Min } from 'class-validator';
+import { plainToInstance, Type } from 'class-transformer';
+
+import { ApiResponseDto } from '@common/dto/api-response.dto';
+
+import { User } from '../../domain/users.entity';
+
+export class GetRanksQueryDto {
+  @ApiProperty({
+    description: '조회할 페이지 번호',
+    minimum: 1,
+    default: 1,
+    required: true,
+  })
+  @IsInt()
+  @Min(1)
+  @Type(() => Number)
+  page: number = 1;
+
+  @ApiProperty({
+    description: '한 페이지당 보여줄 항목 수',
+    minimum: 1,
+    default: 20,
+    required: true,
+  })
+  @IsInt()
+  @Min(1)
+  @Type(() => Number)
+  size: number = 20;
+
+  @ApiPropertyOptional({
+    description: '특정 티어 ID 필터링 (없으면 전체 조회)',
+    example: 3,
+  })
+  @IsOptional()
+  @IsInt()
+  @Type(() => Number)
+  tierId?: number;
+}
+
+export class PaginationMetadataDto {
+  @ApiProperty({ description: '현재 페이지 번호', example: 1 })
+  page: number;
+
+  @ApiProperty({ description: '페이지당 항목 수', example: 20 })
+  size: number;
+
+  @ApiProperty({ description: '전체 항목 수', example: 120 })
+  totalItems: number;
+
+  @ApiProperty({ description: '전체 페이지 수', example: 6 })
+  totalPage: number;
+
+  static from(data: {
+    page: number;
+    size: number;
+    totalItems: number;
+    totalPage: number;
+  }): PaginationMetadataDto {
+    return plainToInstance(PaginationMetadataDto, data);
+  }
+}
+
+export class RankTierDto {
+  @ApiProperty({ description: '티어 이름', example: 'Master' })
+  name: string;
+
+  @ApiProperty({ description: '티어 이미지 URL', example: 'https://example.com/master.png' })
+  imageUrl: string | null;
+}
+
+export class RankItemDto {
+  @ApiProperty({ description: '랭킹', example: 1 })
+  ranking: number;
+
+  @ApiProperty({ description: '닉네임', example: 'Jin Park' })
+  nickname: string;
+
+  @ApiProperty({ description: '총 점수', example: 1029342 })
+  totalScore: number;
+
+  @ApiProperty({ description: '프로필 이미지', example: 'https://github.com/profile.png' })
+  profileImage: string | null;
+
+  @ApiProperty({ description: 'github 링크', example: 'https://github.com/user1' })
+  githubUrl: string | null;
+
+  @ApiProperty({ description: '티어 정보', type: RankTierDto, nullable: true })
+  tier: RankTierDto | null;
+
+  static from(user: User, ranking: number): RankItemDto {
+    const dto = new RankItemDto();
+
+    dto.ranking = ranking;
+    dto.nickname = user.nickname;
+    dto.totalScore = Number(user.totalScore);
+    dto.profileImage = user.profileImage;
+    dto.githubUrl = user.githubUrl;
+    dto.tier = user.tier ? { name: user.tier.name, imageUrl: user.tier.imageUrl } : null;
+
+    return dto;
+  }
+}
+
+export class GetRanksResponseDto {
+  @ApiProperty({ description: '랭킹 리스트', type: [RankItemDto] })
+  ranks: RankItemDto[];
+
+  @ApiProperty({ description: '페이지네이션 메타데이터', type: PaginationMetadataDto })
+  metadata: PaginationMetadataDto;
+
+  static from(users: User[], totalItems: number, page: number, size: number): GetRanksResponseDto {
+    const ranks = users.map((user, index) => {
+      const ranking = (page - 1) * size + index + 1;
+      return RankItemDto.from(user, ranking);
+    });
+
+    const metadata = PaginationMetadataDto.from({
+      page,
+      size,
+      totalItems,
+      totalPage: Math.ceil(totalItems / size),
+    });
+
+    return plainToInstance(GetRanksResponseDto, { ranks, metadata });
+  }
+}
+
+export class RanksResponseDto extends ApiResponseDto {
+  @ApiProperty({ description: '랭킹 응답', type: GetRanksResponseDto })
+  data: GetRanksResponseDto;
+}

--- a/src/users/presentation/dto/get-ranks.dto.ts
+++ b/src/users/presentation/dto/get-ranks.dto.ts
@@ -77,8 +77,8 @@ export class RankItemDto {
   @ApiProperty({ description: '닉네임', example: 'Jin Park' })
   nickname: string;
 
-  @ApiProperty({ description: '총 점수', example: 1029342 })
-  totalScore: number;
+  @ApiProperty({ description: '총 점수(int size를 넘길 수 있어 string type)', example: '1029342' })
+  totalScore: string;
 
   @ApiProperty({ description: '프로필 이미지', example: 'https://github.com/profile.png' })
   profileImage: string | null;
@@ -94,7 +94,7 @@ export class RankItemDto {
 
     dto.ranking = ranking;
     dto.nickname = user.nickname;
-    dto.totalScore = Number(user.totalScore);
+    dto.totalScore = user.totalScore.toString();
     dto.profileImage = user.profileImage;
     dto.githubUrl = user.githubUrl;
     dto.tier = user.tier ? { name: user.tier.name, imageUrl: user.tier.imageUrl } : null;

--- a/src/users/presentation/users.controller.spec.ts
+++ b/src/users/presentation/users.controller.spec.ts
@@ -1,0 +1,120 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { Tier } from '@tiers/domain/tiers.entity';
+
+import { UsersController } from './users.controller';
+import { UsersService } from '../application/users.service';
+
+import { User } from '../domain/users.entity';
+
+function createMockTier(overrides: Partial<Tier> = {}): Tier {
+  return Tier.from({
+    id: 1,
+    name: 'bronze',
+    minScore: 0,
+    imageUrl: null,
+    iconUrl: null,
+    ...overrides,
+  });
+}
+
+function createMockUser(overrides: Partial<User> = {}): User {
+  return User.from({
+    id: 1n,
+    email: 'test@test.com',
+    nickname: 'testUser',
+    provider: 'github',
+    providerId: '12345',
+    totalScore: 0n,
+    refreshToken: 'token',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    githubUrl: null,
+    profileImage: null,
+    tierId: null,
+    tier: null,
+    ...overrides,
+  });
+}
+
+describe('UsersController', () => {
+  let controller: UsersController;
+  let mockUsersService: jest.Mocked<UsersService>;
+
+  beforeEach(async () => {
+    mockUsersService = {
+      getRanksByPageAndSize: jest.fn(),
+    } as unknown as jest.Mocked<UsersService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UsersController],
+      providers: [
+        {
+          provide: UsersService,
+          useValue: mockUsersService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<UsersController>(UsersController);
+  });
+
+  describe('getRanks', () => {
+    const mockTier = createMockTier({ name: 'gold' });
+    let mockUsers: User[];
+    let query: { page: number; size: number; tierId?: number };
+
+    beforeEach(() => {
+      mockUsers = [
+        createMockUser({ nickname: 'user1', totalScore: 100n, tier: mockTier }),
+        createMockUser({ nickname: 'user2', totalScore: 90n, tier: mockTier }),
+      ];
+      query = { page: 1, size: 20 };
+
+      mockUsersService.getRanksByPageAndSize.mockResolvedValue([mockUsers, mockUsers.length]);
+    });
+
+    it('서비스를 호출하여 랭킹 데이터를 조회하는지 확인', async () => {
+      await controller.getRanks(query);
+
+      expect(mockUsersService.getRanksByPageAndSize).toHaveBeenCalledWith(
+        query.page,
+        query.size,
+        undefined,
+      );
+    });
+
+    it('유저 목록에 랭킹 정보가 같이 반환되는지 확인', async () => {
+      const result = await controller.getRanks(query);
+
+      expect(result.ranks).toHaveLength(2);
+      expect(result.ranks[0].ranking).toBe(1);
+      expect(result.ranks[0].nickname).toBe('user1');
+      expect(result.ranks[1].ranking).toBe(2);
+      expect(result.ranks[1].nickname).toBe('user2');
+    });
+
+    it('페이지네이션 메타데이터 정보가 반환되는지 확인', async () => {
+      const result = await controller.getRanks(query);
+
+      expect(result.metadata).toEqual({
+        page: 1,
+        size: 20,
+        totalItems: 2,
+        totalPage: 1,
+      });
+    });
+
+    it('tierId가 있으면 서비스에 전달한다', async () => {
+      query.tierId = 3;
+
+      await controller.getRanks(query);
+
+      expect(mockUsersService.getRanksByPageAndSize).toHaveBeenCalledWith(
+        query.page,
+        query.size,
+        3,
+      );
+    });
+  });
+});

--- a/src/users/presentation/users.controller.ts
+++ b/src/users/presentation/users.controller.ts
@@ -1,8 +1,9 @@
 import { Controller, Get, Query } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 
 import { UsersService } from '../application/users.service';
-import { GetRanksQueryDto, GetRanksResponseDto, RanksResponseDto } from './dto/get-ranks.dto';
+import { GetRanksQueryDto, GetRanksResponseDto } from './dto/get-ranks.dto';
+import { ApiGetRanks } from './decorators/get-ranks-swagger.decorator';
 
 @ApiTags('Users')
 @Controller('users')
@@ -10,12 +11,7 @@ export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
   @Get('/ranks')
-  @ApiOperation({ summary: '유저 전체, 티어별 랭킹 조회' })
-  @ApiResponse({
-    status: 200,
-    description: '유저 랭킹 전체 조회 성공',
-    type: RanksResponseDto,
-  })
+  @ApiGetRanks()
   async getRanks(@Query() query: GetRanksQueryDto): Promise<GetRanksResponseDto> {
     const { page, size, tierId } = query;
 

--- a/src/users/presentation/users.controller.ts
+++ b/src/users/presentation/users.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+
+import { UsersService } from '../application/users.service';
+import { GetRanksQueryDto, GetRanksResponseDto, RanksResponseDto } from './dto/get-ranks.dto';
+
+@ApiTags('Users')
+@Controller('users')
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get('/ranks')
+  @ApiOperation({ summary: '유저 전체, 티어별 랭킹 조회' })
+  @ApiResponse({
+    status: 200,
+    description: '유저 랭킹 전체 조회 성공',
+    type: RanksResponseDto,
+  })
+  async getRanks(@Query() query: GetRanksQueryDto): Promise<GetRanksResponseDto> {
+    const { page, size, tierId } = query;
+
+    const [users, totalItems] = await this.usersService.getRanksByPageAndSize(page, size, tierId);
+
+    return GetRanksResponseDto.from(users, totalItems, page, size);
+  }
+}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { UsersController } from './presentation/users.controller';
+import { UsersService } from './application/users.service';
+
+import { USER_REPOSITORY } from './domain/users.repository.interface';
+import { UsersRepositoryImpl } from './infrastructure/users.repository';
+
+@Module({
+  controllers: [UsersController],
+  providers: [
+    UsersService,
+    {
+      provide: USER_REPOSITORY,
+      useClass: UsersRepositoryImpl,
+    },
+  ],
+})
+export class UsersModule {}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "prisma"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
       "@prisma/*": ["src/prisma/*"],
       "@sse-sample/*": ["src/sse-sample/*"],
       "@tiers/*": ["src/tiers/*"],
+      "@users/*": ["src/users/*"],
 		},
   }
 }


### PR DESCRIPTION
# 백엔드 PR
유저 랭킹 조회 API를 구현했습니다. Domain, Application, Infrastructure, Presentation 4개의 레이어로 구성되어 있으며, 
service, controller에 대한 테스트 코드가 포함되어 있습니다.

   ## 🔗 관련 Issue

   Closes #12

   ## 🎯 변경 내용

   - [x] User 도메인 엔티티 및 Repository 인터페이스 정의 (Domain Layer)
   - [x] User Repository Prisma 구현체 추가 (Infrastructure Layer)
   - [x] 랭킹 조회 비즈니스 로직 구현 (Application Layer - UsersService)
   - [x] 랭킹 조회 API 엔드포인트 추가 (Presentation Layer - UsersController)
   - [x] 요청/응답 DTO 및 랭킹 계산 로직 구현
   - [x] Service 및 Controller 레이어 단위 테스트 추가
   - [x] tsconfig path alias 및 Jest name mapper 설정

   ## 📌 추가 참고사항
   - 4-Layer Clean Architecture (Presentation → Application → Domain ← Infrastructure) 구조를 따릅니다
   - 테스트 커버리지: Service 테스트, Controller 테스트 포함
   - DI Token 규칙: `USER_REPOSITORY` 사용"

## 스크린샷
#### API 호출
<img width="1167" height="723" alt="image" src="https://github.com/user-attachments/assets/d81cf87e-b6b2-49a8-a6e3-b4b091e5a0ba" />

#### Swagger
<img width="803" height="562" alt="image" src="https://github.com/user-attachments/assets/e71c9de7-cc4d-4592-9605-b666214bed5e" />
<img width="637" height="635" alt="image" src="https://github.com/user-attachments/assets/2625a3e5-0f16-48cc-9c66-cc1a23172427" />

#### Validation error
<img width="625" height="187" alt="image" src="https://github.com/user-attachments/assets/cabc854a-b2c0-452b-a66e-2612ac29131b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a /users/ranks endpoint returning paginated leaderboards sorted by total score with optional tier filtering; responses include ranking, nickname, totalScore, profileImage, githubUrl, tier info, and pagination metadata.
  * New users module (service, controller, repository) powering the endpoint; app now registers users and games modules.

* **Documentation**
  * Swagger docs updated for the ranks endpoint and adjusted response envelope usage for game-related endpoints.

* **Tests**
  * New unit and controller tests covering service logic and controller responses.

* **Chores**
  * Added TypeScript path alias and Jest moduleNameMapper for user modules; build/dev config updated to include Prisma artifacts at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->