### PR TITLE
[게임] 게임종료후 게임 세션 저장 API 작성

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,20 @@
   "trailingComma": "all",
   "tabWidth": 2,
   "semi": true,
-  "printWidth": 100
+  "printWidth": 100,
+  "plugins": ["@ianvs/prettier-plugin-sort-imports"],
+  "importOrder": [
+    "<BUILTIN_MODULES>",
+    "^@nestjs/(.*)$",
+    "",
+    "^@prisma/client$",
+    "<THIRD_PARTY_MODULES>",
+    "",
+    "^@/(.*)$",
+    "^@(config|common|prisma|sse-sample|tiers|users|games)/(.*)$",
+    "",
+    "^[./]"
+  ],
+  "importOrderParserPlugins": ["typescript", "decorators-legacy"],
+  "importOrderTypeScriptVersion": "5.7.3"
 }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@commitlint/config-conventional": "^20.3.1",
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.18.0",
+    "@ianvs/prettier-plugin-sort-imports": "^4.7.1",
     "@nestjs/cli": "^11.0.0",
     "@nestjs/schematics": "^11.0.0",
     "@nestjs/testing": "^11.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@eslint/js':
         specifier: ^9.18.0
         version: 9.39.2
+      '@ianvs/prettier-plugin-sort-imports':
+        specifier: ^4.7.1
+        version: 4.7.1(prettier@3.8.1)
       '@nestjs/cli':
         specifier: ^11.0.0
         version: 11.0.16(@swc/cli@0.6.0(@swc/core@1.15.10)(chokidar@4.0.3))(@swc/core@1.15.10)(@types/node@22.19.7)
@@ -491,6 +494,24 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@ianvs/prettier-plugin-sort-imports@4.7.1':
+    resolution: {integrity: sha512-jmTNYGlg95tlsoG3JLCcuC4BrFELJtLirLAkQW/71lXSyOhVt/Xj7xWbbGcuVbNq1gwWgSyMrPjJc9Z30hynVw==}
+    peerDependencies:
+      '@prettier/plugin-oxc': ^0.0.4 || ^0.1.0
+      '@vue/compiler-sfc': 2.7.x || 3.x
+      content-tag: ^4.0.0
+      prettier: 2 || 3 || ^4.0.0-0
+      prettier-plugin-ember-template-tag: ^2.1.0
+    peerDependenciesMeta:
+      '@prettier/plugin-oxc':
+        optional: true
+      '@vue/compiler-sfc':
+        optional: true
+      content-tag:
+        optional: true
+      prettier-plugin-ember-template-tag:
+        optional: true
 
   '@inquirer/ansi@1.0.2':
     resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
@@ -4947,6 +4968,17 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@ianvs/prettier-plugin-sort-imports@4.7.1(prettier@3.8.1)':
+    dependencies:
+      '@babel/generator': 7.28.6
+      '@babel/parser': 7.28.6
+      '@babel/traverse': 7.28.6
+      '@babel/types': 7.28.6
+      prettier: 3.8.1
+      semver: 7.7.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@inquirer/ansi@1.0.2': {}
 

--- a/prisma/seeds/category.seed.ts
+++ b/prisma/seeds/category.seed.ts
@@ -1,10 +1,14 @@
 import { PrismaClient } from '@prisma/client';
 
-const categories = ['Git', 'Linux', 'Docker'];
+const categories = [
+  { name: 'Git', iconUrl: 'https://cdn.orvit.net/categories/git.png' },
+  { name: 'Linux', iconUrl: 'https://cdn.orvit.net/categories/linux.png' },
+  { name: 'Docker', iconUrl: 'https://cdn.orvit.net/categories/docker.png' },
+];
 
 export async function seedCategories(prisma: PrismaClient) {
   const result = await prisma.category.createMany({
-    data: categories.map((name) => ({ name })),
+    data: categories.map((category) => ({ name: category.name, iconUrl: category.iconUrl })),
     skipDuplicates: true,
   });
 

--- a/src/games/application/games.service.spec.ts
+++ b/src/games/application/games.service.spec.ts
@@ -270,6 +270,8 @@ describe('GamesService', () => {
 
         expect(gameRepository.saveGameSession).not.toHaveBeenCalled();
       });
+    });
+  });
   describe('getUserMistakeAnalysis', () => {
     const userId = 1n;
     let mockCommands: FrequentWrongCommand[];

--- a/src/games/application/games.service.spec.ts
+++ b/src/games/application/games.service.spec.ts
@@ -1,8 +1,8 @@
-import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { GamesService } from './games.service';
-import { GAME_REPOSITORY, IGameRepository } from '../domain/games.repository.interface';
+import { Test, TestingModule } from '@nestjs/testing';
+
 import { GameCategory } from '../domain/game-categories.entity';
+import { ClientAnswer } from '../domain/game-client-answers.interface';
 import { GameOptions } from '../domain/game-options.entity';
 import { GameProblem } from '../domain/game-problem.entity';
 import {
@@ -11,7 +11,13 @@ import {
   MAX_PROBLEMS_PER_GAME,
   ProblemDifficulty,
 } from '../domain/game.business-rules';
-import { ClientAnswer } from '../domain/game-client-answers.interface';
+import { GAME_REPOSITORY, IGameRepository } from '../domain/games.repository.interface';
+import {
+  FrequentWrongCategory,
+  FrequentWrongCommand,
+  UserMistakeAnalysis,
+} from '../domain/user-mistake-analysis.entity';
+import { GamesService } from './games.service';
 
 const createMockProblem = (id: number, difficulty: ProblemDifficulty = 'Easy'): GameProblem =>
   GameProblem.from({
@@ -33,11 +39,6 @@ const createClientAnswers = (
     solved: false,
     ...overrides[i],
   }));
-import {
-  FrequentWrongCommand,
-  FrequentWrongCategory,
-  UserMistakeAnalysis,
-} from '../domain/user-mistake-analysis.entity';
 
 describe('GamesService', () => {
   let service: GamesService;
@@ -70,9 +71,9 @@ describe('GamesService', () => {
   describe('getGameOptions', () => {
     it('게임옵션 정보 조회에 성공한다.', async () => {
       const expectedCategories: GameCategory[] = [
-        { id: 1, name: 'Git' },
-        { id: 2, name: 'Linux' },
-        { id: 3, name: 'Docker' },
+        { id: 1, name: 'Git', iconUrl: 'https://fake-storage/categories/git.png' },
+        { id: 2, name: 'Linux', iconUrl: 'https://fake-storage/categories/linux.png' },
+        { id: 3, name: 'Docker', iconUrl: 'https://fake-storage/categories/docker.png' },
       ];
       gameRepository.getCategories.mockResolvedValue(expectedCategories);
 
@@ -188,19 +189,27 @@ describe('GamesService', () => {
           }),
         ).rejects.toThrow(NotFoundException);
 
-        expect(gameRepository.findProblemsByIds).not.toHaveBeenCalled();
         expect(gameRepository.saveGameSession).not.toHaveBeenCalled();
       });
 
-      it(`clientAnswers가 ${MAX_PROBLEMS_PER_GAME}개가 아니면 BadRequestException을 던진다.`, async () => {
+      it('clientAnswers에 중복된 problemId가 포함되어 있으면 BadRequestException을 던진다.', async () => {
         gameRepository.categoryExists.mockResolvedValue(true);
+
+        // problemId "1"을 2번 사용하여 중복 발생 (총 20개는 유지)
+        const clientAnswers = createClientAnswers({
+          19: {
+            problemId: '1',
+            inputs: [{ input: 'git init', isCorrect: true }],
+            solved: true,
+          },
+        });
 
         await expect(
           service.createGameSession({
             categoryId: 1,
             difficultyMode: GameDifficultyMode.Easy,
             score: 0,
-            clientAnswers: [],
+            clientAnswers,
           }),
         ).rejects.toThrow(BadRequestException);
 

--- a/src/games/application/games.service.spec.ts
+++ b/src/games/application/games.service.spec.ts
@@ -5,8 +5,34 @@ import { GAME_REPOSITORY, IGameRepository } from '../domain/games.repository.int
 import { GameCategory } from '../domain/game-categories.entity';
 import { GameOptions } from '../domain/game-options.entity';
 import { GameProblem } from '../domain/game-problem.entity';
-import { GameDifficultyMode } from '../domain/game.business-rules';
+import {
+  DIFFICULTY_SCORES,
+  GameDifficultyMode,
+  MAX_PROBLEMS_PER_GAME,
+  ProblemDifficulty,
+} from '../domain/game.business-rules';
 import { ClientAnswer } from '../domain/game-client-answers.interface';
+
+const createMockProblem = (id: number, difficulty: ProblemDifficulty = 'Easy'): GameProblem =>
+  GameProblem.from({
+    id: BigInt(id),
+    title: `문제 ${id}`,
+    subCategoryName: 'Test',
+    text: `문제 ${id}`,
+    answer: `answer`,
+    point: DIFFICULTY_SCORES[difficulty],
+    difficulty,
+  });
+
+const createClientAnswers = (
+  overrides: Record<number, Partial<ClientAnswer>> = {},
+): ClientAnswer[] =>
+  Array.from({ length: MAX_PROBLEMS_PER_GAME }, (_, i) => ({
+    problemId: String(i + 1),
+    inputs: [],
+    solved: false,
+    ...overrides[i],
+  }));
 
 describe('GamesService', () => {
   let service: GamesService;
@@ -52,55 +78,11 @@ describe('GamesService', () => {
   });
 
   describe('createGameSession', () => {
-    const mockProblems = [
-      GameProblem.from({
-        id: BigInt(1),
-        title: 'Git 문제 1',
-        subCategoryName: 'Git Basics',
-        text: 'git init은?',
-        answer: 'git init',
-        point: 10,
-        difficulty: GameDifficultyMode.Easy,
-      }),
-      GameProblem.from({
-        id: BigInt(2),
-        title: 'Git 문제 2',
-        subCategoryName: 'Git Basics',
-        text: 'git commit은?',
-        answer: 'git commit',
-        point: 30,
-        difficulty: GameDifficultyMode.Normal,
-      }),
-      GameProblem.from({
-        id: BigInt(3),
-        title: 'Git 문제 3',
-        subCategoryName: 'Git Advanced',
-        text: 'git rebase는?',
-        answer: 'git rebase',
-        point: 50,
-        difficulty: GameDifficultyMode.Hard,
-      }),
-    ];
-
-    const createClientAnswers = (): ClientAnswer[] => [
-      {
-        problemId: '1',
-        inputs: [{ input: 'git init', isCorrect: true }],
-        solved: true,
-      },
-      {
-        problemId: '2',
-        inputs: [
-          { input: 'git add', isCorrect: false },
-          { input: 'git commit', isCorrect: true },
-        ],
-        solved: true,
-      },
-      {
-        problemId: '3',
-        inputs: [{ input: 'git merge', isCorrect: false }],
-        solved: false,
-      },
+    const mockProblems: GameProblem[] = [
+      createMockProblem(1, 'Easy'),
+      createMockProblem(2, 'Normal'),
+      createMockProblem(3, 'Hard'),
+      ...Array.from({ length: 17 }, (_, i) => createMockProblem(i + 4, 'Easy')),
     ];
 
     describe('✅ 성공 케이스', () => {
@@ -109,67 +91,42 @@ describe('GamesService', () => {
         gameRepository.findProblemsByIds.mockResolvedValue(mockProblems);
         gameRepository.saveGameSession.mockResolvedValue(BigInt(100));
 
-        const clientAnswers = createClientAnswers();
+        const clientAnswers = createClientAnswers({
+          0: { inputs: [{ input: 'git init', isCorrect: true }], solved: true },
+          1: {
+            inputs: [
+              { input: 'git add', isCorrect: false },
+              { input: 'git commit', isCorrect: true },
+            ],
+            solved: true,
+          },
+          2: { inputs: [{ input: 'git merge', isCorrect: false }], solved: false },
+        });
 
         const result = await service.createGameSession({
           categoryId: 1,
           difficultyMode: GameDifficultyMode.Normal,
-          score: 999, // 클라이언트 점수는 무시됨
+          score: 999,
           clientAnswers,
         });
 
         expect(result).toBe(BigInt(100));
-
-        expect(gameRepository.categoryExists).toHaveBeenCalledWith(1);
-        expect(gameRepository.findProblemsByIds).toHaveBeenCalledWith([
-          BigInt(1),
-          BigInt(2),
-          BigInt(3),
-        ]);
         // Easy(10) + Normal(30) = 40 (Hard는 미해결)
-        expect(gameRepository.saveGameSession).toHaveBeenCalledWith({
-          categoryId: 1,
-          difficultyMode: GameDifficultyMode.Normal,
-          score: 40,
-          totalProblemCount: 3,
-          correctProblemCount: 2,
-          logs: [
-            {
-              problemId: BigInt(1),
-              inputs: [{ input: 'git init', isCorrect: true }],
-              isSolved: true,
-              tryCount: 1,
-            },
-            {
-              problemId: BigInt(2),
-              inputs: [
-                { input: 'git add', isCorrect: false },
-                { input: 'git commit', isCorrect: true },
-              ],
-              isSolved: true,
-              tryCount: 2,
-            },
-            {
-              problemId: BigInt(3),
-              inputs: [{ input: 'git merge', isCorrect: false }],
-              isSolved: false,
-              tryCount: 1,
-            },
-          ],
-        });
+        expect(gameRepository.saveGameSession).toHaveBeenCalledWith(
+          expect.objectContaining({
+            score: 40,
+            totalProblemCount: MAX_PROBLEMS_PER_GAME,
+            correctProblemCount: 2,
+          }),
+        );
       });
+
       it('모든 문제를 틀려도 gameSessionId를 정상 반환한다.', async () => {
         gameRepository.categoryExists.mockResolvedValue(true);
-        gameRepository.findProblemsByIds.mockResolvedValue([mockProblems[0]]);
+        gameRepository.findProblemsByIds.mockResolvedValue(mockProblems);
         gameRepository.saveGameSession.mockResolvedValue(BigInt(101));
 
-        const clientAnswers: ClientAnswer[] = [
-          {
-            problemId: '1',
-            inputs: [{ input: 'wrong', isCorrect: false }],
-            solved: false,
-          },
-        ];
+        const clientAnswers = createClientAnswers();
 
         const result = await service.createGameSession({
           categoryId: 1,
@@ -180,48 +137,22 @@ describe('GamesService', () => {
 
         expect(result).toBe(BigInt(101));
         expect(gameRepository.saveGameSession).toHaveBeenCalledWith(
-          expect.objectContaining({ score: 0, correctProblemCount: 0, totalProblemCount: 1 }),
+          expect.objectContaining({
+            score: 0,
+            correctProblemCount: 0,
+            totalProblemCount: MAX_PROBLEMS_PER_GAME,
+          }),
         );
       });
-      it('clientAnswers가 빈 배열이면 점수 0으로 세션을 저장한다.', async () => {
-        gameRepository.categoryExists.mockResolvedValue(true);
-        gameRepository.findProblemsByIds.mockResolvedValue([]);
-        gameRepository.saveGameSession.mockResolvedValue(BigInt(102));
 
-        const result = await service.createGameSession({
-          categoryId: 1,
-          difficultyMode: GameDifficultyMode.Random,
-          score: 0,
-          clientAnswers: [],
-        });
-
-        expect(result).toBe(BigInt(102));
-        expect(gameRepository.saveGameSession).toHaveBeenCalledWith(
-          expect.objectContaining({ score: 0, totalProblemCount: 0, correctProblemCount: 0 }),
-        );
-      });
       it('실제로는 0점인데 클라이언트가 999점으로 점수조작하더라도, 0점으로 계산됨을 성공한다', async () => {
         gameRepository.categoryExists.mockResolvedValue(true);
         gameRepository.findProblemsByIds.mockResolvedValue(mockProblems);
         gameRepository.saveGameSession.mockResolvedValue(BigInt(103));
 
-        const clientAnswers: ClientAnswer[] = [
-          {
-            problemId: '1',
-            inputs: [{ input: 'wrong', isCorrect: false }],
-            solved: false,
-          },
-          {
-            problemId: '2',
-            inputs: [{ input: 'wrong', isCorrect: false }],
-            solved: false,
-          },
-          {
-            problemId: '3',
-            inputs: [{ input: 'wrong', isCorrect: false }],
-            solved: false,
-          },
-        ];
+        const clientAnswers = createClientAnswers({
+          0: { inputs: [{ input: 'wrong', isCorrect: false }], solved: false },
+        });
 
         const result = await service.createGameSession({
           categoryId: 1,
@@ -236,6 +167,7 @@ describe('GamesService', () => {
         );
       });
     });
+
     describe('❌ 실패 케이스', () => {
       it('존재하지 않는 카테고리면 NotFoundException을 던진다.', async () => {
         gameRepository.categoryExists.mockResolvedValue(false);
@@ -245,7 +177,7 @@ describe('GamesService', () => {
             categoryId: 999,
             difficultyMode: GameDifficultyMode.Easy,
             score: 0,
-            clientAnswers: [],
+            clientAnswers: createClientAnswers(),
           }),
         ).rejects.toThrow(NotFoundException);
 
@@ -253,10 +185,27 @@ describe('GamesService', () => {
         expect(gameRepository.saveGameSession).not.toHaveBeenCalled();
       });
 
+      it(`clientAnswers가 ${MAX_PROBLEMS_PER_GAME}개가 아니면 BadRequestException을 던진다.`, async () => {
+        gameRepository.categoryExists.mockResolvedValue(true);
+
+        await expect(
+          service.createGameSession({
+            categoryId: 1,
+            difficultyMode: GameDifficultyMode.Easy,
+            score: 0,
+            clientAnswers: [],
+          }),
+        ).rejects.toThrow(BadRequestException);
+
+        expect(gameRepository.findProblemsByIds).not.toHaveBeenCalled();
+        expect(gameRepository.saveGameSession).not.toHaveBeenCalled();
+      });
+
       it('존재하지 않는 문제가 포함되어 있으면 NotFoundException을 던진다.', async () => {
         gameRepository.categoryExists.mockResolvedValue(true);
-        // 3개 요청했는데 2개만 조회됨 (problemId=3 누락)
-        gameRepository.findProblemsByIds.mockResolvedValue([mockProblems[0], mockProblems[1]]);
+        // 20개 요청했는데 19개만 조회됨 (problemId=3 누락)
+        const problemsWithout3 = mockProblems.filter((p) => p.id !== BigInt(3));
+        gameRepository.findProblemsByIds.mockResolvedValue(problemsWithout3);
 
         const clientAnswers = createClientAnswers();
 
@@ -267,24 +216,21 @@ describe('GamesService', () => {
             score: 0,
             clientAnswers,
           }),
-        ).rejects.toThrow(
-          new NotFoundException('존재하지 않는 문제 ID가 포함되어 있습니다. (problemId: 3)'),
-        );
+        ).rejects.toThrow(NotFoundException);
 
         expect(gameRepository.saveGameSession).not.toHaveBeenCalled();
       });
 
       it('solved=true인데 정답 입력이 없으면 BadRequestException을 던진다.', async () => {
         gameRepository.categoryExists.mockResolvedValue(true);
-        gameRepository.findProblemsByIds.mockResolvedValue([mockProblems[0]]);
+        gameRepository.findProblemsByIds.mockResolvedValue(mockProblems);
 
-        const clientAnswers: ClientAnswer[] = [
-          {
-            problemId: '1',
+        const clientAnswers = createClientAnswers({
+          0: {
             inputs: [{ input: 'wrong', isCorrect: false }],
-            solved: true, // solved=true인데 isCorrect=true인 입력이 없음
+            solved: true,
           },
-        ];
+        });
 
         await expect(
           service.createGameSession({
@@ -300,15 +246,11 @@ describe('GamesService', () => {
 
       it('solved=true이고 inputs가 빈 배열이면 BadRequestException을 던진다.', async () => {
         gameRepository.categoryExists.mockResolvedValue(true);
-        gameRepository.findProblemsByIds.mockResolvedValue([mockProblems[0]]);
+        gameRepository.findProblemsByIds.mockResolvedValue(mockProblems);
 
-        const clientAnswers: ClientAnswer[] = [
-          {
-            problemId: '1',
-            inputs: [],
-            solved: true, // solved=true인데 inputs 자체가 비어있음
-          },
-        ];
+        const clientAnswers = createClientAnswers({
+          0: { inputs: [], solved: true },
+        });
 
         await expect(
           service.createGameSession({

--- a/src/games/application/games.service.spec.ts
+++ b/src/games/application/games.service.spec.ts
@@ -1,8 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { GamesService } from './games.service';
 import { GAME_REPOSITORY, IGameRepository } from '../domain/games.repository.interface';
 import { GameCategory } from '../domain/game-categories.entity';
 import { GameOptions } from '../domain/game-options.entity';
+import { GameProblem } from '../domain/game-problem.entity';
+import { GameDifficultyMode } from '../domain/game.business-rules';
+import { ClientAnswer } from '../domain/game-client-answers.interface';
 
 describe('GamesService', () => {
   let service: GamesService;
@@ -11,6 +15,9 @@ describe('GamesService', () => {
   beforeEach(async () => {
     const mockGameRepository: Partial<jest.Mocked<IGameRepository>> = {
       getCategories: jest.fn(),
+      categoryExists: jest.fn(),
+      findProblemsByIds: jest.fn(),
+      saveGameSession: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -41,6 +48,279 @@ describe('GamesService', () => {
       expect(result).toEqual(GameOptions.from(expectedCategories));
 
       expect(gameRepository.getCategories).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('createGameSession', () => {
+    const mockProblems = [
+      GameProblem.from({
+        id: BigInt(1),
+        title: 'Git 문제 1',
+        subCategoryName: 'Git Basics',
+        text: 'git init은?',
+        answer: 'git init',
+        point: 10,
+        difficulty: GameDifficultyMode.Easy,
+      }),
+      GameProblem.from({
+        id: BigInt(2),
+        title: 'Git 문제 2',
+        subCategoryName: 'Git Basics',
+        text: 'git commit은?',
+        answer: 'git commit',
+        point: 30,
+        difficulty: GameDifficultyMode.Normal,
+      }),
+      GameProblem.from({
+        id: BigInt(3),
+        title: 'Git 문제 3',
+        subCategoryName: 'Git Advanced',
+        text: 'git rebase는?',
+        answer: 'git rebase',
+        point: 50,
+        difficulty: GameDifficultyMode.Hard,
+      }),
+    ];
+
+    const createClientAnswers = (): ClientAnswer[] => [
+      {
+        problemId: '1',
+        inputs: [{ input: 'git init', isCorrect: true }],
+        solved: true,
+      },
+      {
+        problemId: '2',
+        inputs: [
+          { input: 'git add', isCorrect: false },
+          { input: 'git commit', isCorrect: true },
+        ],
+        solved: true,
+      },
+      {
+        problemId: '3',
+        inputs: [{ input: 'git merge', isCorrect: false }],
+        solved: false,
+      },
+    ];
+
+    describe('✅ 성공 케이스', () => {
+      it('게임 세션을 정상적으로 저장하고 gameSessionId를 반환한다.', async () => {
+        gameRepository.categoryExists.mockResolvedValue(true);
+        gameRepository.findProblemsByIds.mockResolvedValue(mockProblems);
+        gameRepository.saveGameSession.mockResolvedValue(BigInt(100));
+
+        const clientAnswers = createClientAnswers();
+
+        const result = await service.createGameSession({
+          categoryId: 1,
+          difficultyMode: GameDifficultyMode.Normal,
+          score: 999, // 클라이언트 점수는 무시됨
+          clientAnswers,
+        });
+
+        expect(result).toBe(BigInt(100));
+
+        expect(gameRepository.categoryExists).toHaveBeenCalledWith(1);
+        expect(gameRepository.findProblemsByIds).toHaveBeenCalledWith([
+          BigInt(1),
+          BigInt(2),
+          BigInt(3),
+        ]);
+        // Easy(10) + Normal(30) = 40 (Hard는 미해결)
+        expect(gameRepository.saveGameSession).toHaveBeenCalledWith({
+          categoryId: 1,
+          difficultyMode: GameDifficultyMode.Normal,
+          score: 40,
+          totalProblemCount: 3,
+          correctProblemCount: 2,
+          logs: [
+            {
+              problemId: BigInt(1),
+              inputs: [{ input: 'git init', isCorrect: true }],
+              isSolved: true,
+              tryCount: 1,
+            },
+            {
+              problemId: BigInt(2),
+              inputs: [
+                { input: 'git add', isCorrect: false },
+                { input: 'git commit', isCorrect: true },
+              ],
+              isSolved: true,
+              tryCount: 2,
+            },
+            {
+              problemId: BigInt(3),
+              inputs: [{ input: 'git merge', isCorrect: false }],
+              isSolved: false,
+              tryCount: 1,
+            },
+          ],
+        });
+      });
+      it('모든 문제를 틀려도 gameSessionId를 정상 반환한다.', async () => {
+        gameRepository.categoryExists.mockResolvedValue(true);
+        gameRepository.findProblemsByIds.mockResolvedValue([mockProblems[0]]);
+        gameRepository.saveGameSession.mockResolvedValue(BigInt(101));
+
+        const clientAnswers: ClientAnswer[] = [
+          {
+            problemId: '1',
+            inputs: [{ input: 'wrong', isCorrect: false }],
+            solved: false,
+          },
+        ];
+
+        const result = await service.createGameSession({
+          categoryId: 1,
+          difficultyMode: GameDifficultyMode.Easy,
+          score: 0,
+          clientAnswers,
+        });
+
+        expect(result).toBe(BigInt(101));
+        expect(gameRepository.saveGameSession).toHaveBeenCalledWith(
+          expect.objectContaining({ score: 0, correctProblemCount: 0, totalProblemCount: 1 }),
+        );
+      });
+      it('clientAnswers가 빈 배열이면 점수 0으로 세션을 저장한다.', async () => {
+        gameRepository.categoryExists.mockResolvedValue(true);
+        gameRepository.findProblemsByIds.mockResolvedValue([]);
+        gameRepository.saveGameSession.mockResolvedValue(BigInt(102));
+
+        const result = await service.createGameSession({
+          categoryId: 1,
+          difficultyMode: GameDifficultyMode.Random,
+          score: 0,
+          clientAnswers: [],
+        });
+
+        expect(result).toBe(BigInt(102));
+        expect(gameRepository.saveGameSession).toHaveBeenCalledWith(
+          expect.objectContaining({ score: 0, totalProblemCount: 0, correctProblemCount: 0 }),
+        );
+      });
+      it('실제로는 0점인데 클라이언트가 999점으로 점수조작하더라도, 0점으로 계산됨을 성공한다', async () => {
+        gameRepository.categoryExists.mockResolvedValue(true);
+        gameRepository.findProblemsByIds.mockResolvedValue(mockProblems);
+        gameRepository.saveGameSession.mockResolvedValue(BigInt(103));
+
+        const clientAnswers: ClientAnswer[] = [
+          {
+            problemId: '1',
+            inputs: [{ input: 'wrong', isCorrect: false }],
+            solved: false,
+          },
+          {
+            problemId: '2',
+            inputs: [{ input: 'wrong', isCorrect: false }],
+            solved: false,
+          },
+          {
+            problemId: '3',
+            inputs: [{ input: 'wrong', isCorrect: false }],
+            solved: false,
+          },
+        ];
+
+        const result = await service.createGameSession({
+          categoryId: 1,
+          difficultyMode: GameDifficultyMode.Easy,
+          score: 999,
+          clientAnswers,
+        });
+
+        expect(result).toBe(BigInt(103));
+        expect(gameRepository.saveGameSession).toHaveBeenCalledWith(
+          expect.objectContaining({ score: 0, correctProblemCount: 0 }),
+        );
+      });
+    });
+    describe('❌ 실패 케이스', () => {
+      it('존재하지 않는 카테고리면 NotFoundException을 던진다.', async () => {
+        gameRepository.categoryExists.mockResolvedValue(false);
+
+        await expect(
+          service.createGameSession({
+            categoryId: 999,
+            difficultyMode: GameDifficultyMode.Easy,
+            score: 0,
+            clientAnswers: [],
+          }),
+        ).rejects.toThrow(NotFoundException);
+
+        expect(gameRepository.findProblemsByIds).not.toHaveBeenCalled();
+        expect(gameRepository.saveGameSession).not.toHaveBeenCalled();
+      });
+
+      it('존재하지 않는 문제가 포함되어 있으면 NotFoundException을 던진다.', async () => {
+        gameRepository.categoryExists.mockResolvedValue(true);
+        // 3개 요청했는데 2개만 조회됨 (problemId=3 누락)
+        gameRepository.findProblemsByIds.mockResolvedValue([mockProblems[0], mockProblems[1]]);
+
+        const clientAnswers = createClientAnswers();
+
+        await expect(
+          service.createGameSession({
+            categoryId: 1,
+            difficultyMode: GameDifficultyMode.Normal,
+            score: 0,
+            clientAnswers,
+          }),
+        ).rejects.toThrow(
+          new NotFoundException('존재하지 않는 문제 ID가 포함되어 있습니다. (problemId: 3)'),
+        );
+
+        expect(gameRepository.saveGameSession).not.toHaveBeenCalled();
+      });
+
+      it('solved=true인데 정답 입력이 없으면 BadRequestException을 던진다.', async () => {
+        gameRepository.categoryExists.mockResolvedValue(true);
+        gameRepository.findProblemsByIds.mockResolvedValue([mockProblems[0]]);
+
+        const clientAnswers: ClientAnswer[] = [
+          {
+            problemId: '1',
+            inputs: [{ input: 'wrong', isCorrect: false }],
+            solved: true, // solved=true인데 isCorrect=true인 입력이 없음
+          },
+        ];
+
+        await expect(
+          service.createGameSession({
+            categoryId: 1,
+            difficultyMode: GameDifficultyMode.Easy,
+            score: 0,
+            clientAnswers,
+          }),
+        ).rejects.toThrow(BadRequestException);
+
+        expect(gameRepository.saveGameSession).not.toHaveBeenCalled();
+      });
+
+      it('solved=true이고 inputs가 빈 배열이면 BadRequestException을 던진다.', async () => {
+        gameRepository.categoryExists.mockResolvedValue(true);
+        gameRepository.findProblemsByIds.mockResolvedValue([mockProblems[0]]);
+
+        const clientAnswers: ClientAnswer[] = [
+          {
+            problemId: '1',
+            inputs: [],
+            solved: true, // solved=true인데 inputs 자체가 비어있음
+          },
+        ];
+
+        await expect(
+          service.createGameSession({
+            categoryId: 1,
+            difficultyMode: GameDifficultyMode.Easy,
+            score: 0,
+            clientAnswers,
+          }),
+        ).rejects.toThrow(BadRequestException);
+
+        expect(gameRepository.saveGameSession).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/src/games/application/games.service.ts
+++ b/src/games/application/games.service.ts
@@ -130,6 +130,7 @@ export class GamesService {
 
     return calculateServerScore(solvedDifficulties);
   }
+  /*
    * @description 사용자의 명령어, 카테고리 실수 분석 조회
    * - 자주 틀린 명령어 Top 5 (서브 카테고리 별)
    * - 자주 틀린 카테고리 (오답 비율 포함)

--- a/src/games/application/games.service.ts
+++ b/src/games/application/games.service.ts
@@ -72,10 +72,15 @@ export class GamesService {
    * @description 클라이언트가 푼 게임문제 검증
    */
   private async validateGameProblems(clientAnswers: ClientAnswer[]): Promise<GameProblem[]> {
-    const problemIds = clientAnswers.map((a) => BigInt(a.problemId));
-    const problems = await this.gameRepository.findProblemsByIds(problemIds);
+    if (clientAnswers.length === 0) {
+      return [];
+    }
 
-    if (problems.length !== problemIds.length) {
+    const problemIds = clientAnswers.map((a) => BigInt(a.problemId));
+    const uniqueProblemIds = [...new Set(problemIds)];
+    const problems = await this.gameRepository.findProblemsByIds(uniqueProblemIds);
+
+    if (problems.length !== uniqueProblemIds.length) {
       const foundIds = new Set(problems.map((p) => p.id));
       const missingIds = problemIds.filter((id) => !foundIds.has(id));
       throw new NotFoundException(

--- a/src/games/application/games.service.ts
+++ b/src/games/application/games.service.ts
@@ -1,15 +1,12 @@
 import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common';
-import { GAME_REPOSITORY, IGameRepository } from '../domain/games.repository.interface';
+
+import { ClientAnswer } from '../domain/game-client-answers.interface';
 import { GameOptions } from '../domain/game-options.entity';
 import { GameProblem } from '../domain/game-problem.entity';
-import {
-  MAX_PROBLEMS_PER_GAME,
-  ProblemDifficulty,
-  calculateServerScore,
-} from '../domain/game.business-rules';
-import { CreateGameSessionServiceRequestDto } from './service-dto/create-game-session.service-dto';
-import { ClientAnswer } from '../domain/game-client-answers.interface';
+import { calculateServerScore, ProblemDifficulty } from '../domain/game.business-rules';
+import { GAME_REPOSITORY, IGameRepository } from '../domain/games.repository.interface';
 import { UserMistakeAnalysis } from '../domain/user-mistake-analysis.entity';
+import { CreateGameSessionServiceRequestDto } from './service-dto/create-game-session.service-dto';
 
 @Injectable()
 export class GamesService {
@@ -56,10 +53,12 @@ export class GamesService {
     categoryId: number,
     clientAnswers: ClientAnswer[],
   ): Promise<number> {
-    await this.validateCategory(categoryId);
-    this.validateClientAnswersCount(clientAnswers);
-    const problems = await this.validateGameProblems(clientAnswers);
     this.validateAnswerIntegrity(clientAnswers);
+
+    const [, problems] = await Promise.all([
+      this.validateCategory(categoryId),
+      this.validateAndMatchedGameProblems(clientAnswers),
+    ]);
     return this.calculateScore(clientAnswers, problems);
   }
 
@@ -75,25 +74,23 @@ export class GamesService {
   }
 
   /**
-   * @description 게임 문제 수 검증 - 게임당 정확히 MAX_PROBLEMS_PER_GAME(20)개여야 함
-   */
-  private validateClientAnswersCount(clientAnswers: ClientAnswer[]): void {
-    if (clientAnswers.length !== MAX_PROBLEMS_PER_GAME) {
-      throw new BadRequestException(`clientAnswers는 ${MAX_PROBLEMS_PER_GAME}개여야 합니다.`);
-    }
-  }
-
-  /**
    * @description 클라이언트가 푼 게임문제 검증
    */
-  private async validateGameProblems(clientAnswers: ClientAnswer[]): Promise<GameProblem[]> {
+  private async validateAndMatchedGameProblems(
+    clientAnswers: ClientAnswer[],
+  ): Promise<GameProblem[]> {
     const problemIds = clientAnswers.map((a) => BigInt(a.problemId));
     const uniqueProblemIds = [...new Set(problemIds)];
+
+    if (uniqueProblemIds.length !== problemIds.length) {
+      throw new BadRequestException('clientAnswers에 중복된 problemId가 포함되어 있습니다.');
+    }
+
     const problems = await this.gameRepository.findProblemsByIds(uniqueProblemIds);
 
     if (problems.length !== uniqueProblemIds.length) {
       const foundIds = new Set(problems.map((p) => p.id));
-      const missingIds = problemIds.filter((id) => !foundIds.has(id));
+      const missingIds = uniqueProblemIds.filter((id) => !foundIds.has(id));
       throw new NotFoundException(
         `존재하지 않는 문제 ID가 포함되어 있습니다. (problemId: ${missingIds.join(', ')})`,
       );
@@ -103,7 +100,7 @@ export class GamesService {
   }
 
   /**
-   * @description 클라이언트 문제풀이 정답/오답 검증
+   * @description 클라이언트 문제풀이 입력데이터가 정답인지 검증
    */
   private validateAnswerIntegrity(clientAnswers: ClientAnswer[]): void {
     const invalid = clientAnswers.find(

--- a/src/games/application/games.service.ts
+++ b/src/games/application/games.service.ts
@@ -2,7 +2,11 @@ import { BadRequestException, Inject, Injectable, NotFoundException } from '@nes
 import { GAME_REPOSITORY, IGameRepository } from '../domain/games.repository.interface';
 import { GameOptions } from '../domain/game-options.entity';
 import { GameProblem } from '../domain/game-problem.entity';
-import { ProblemDifficulty, calculateServerScore } from '../domain/game.business-rules';
+import {
+  MAX_PROBLEMS_PER_GAME,
+  ProblemDifficulty,
+  calculateServerScore,
+} from '../domain/game.business-rules';
 import { CreateGameSessionServiceRequestDto } from './service-dto/create-game-session.service-dto';
 import { ClientAnswer } from '../domain/game-client-answers.interface';
 
@@ -52,6 +56,7 @@ export class GamesService {
     clientAnswers: ClientAnswer[],
   ): Promise<number> {
     await this.validateCategory(categoryId);
+    this.validateClientAnswersCount(clientAnswers);
     const problems = await this.validateGameProblems(clientAnswers);
     this.validateAnswerIntegrity(clientAnswers);
     return this.calculateScore(clientAnswers, problems);
@@ -69,13 +74,18 @@ export class GamesService {
   }
 
   /**
+   * @description 게임 문제 수 검증 - 게임당 정확히 MAX_PROBLEMS_PER_GAME(20)개여야 함
+   */
+  private validateClientAnswersCount(clientAnswers: ClientAnswer[]): void {
+    if (clientAnswers.length !== MAX_PROBLEMS_PER_GAME) {
+      throw new BadRequestException(`clientAnswers는 ${MAX_PROBLEMS_PER_GAME}개여야 합니다.`);
+    }
+  }
+
+  /**
    * @description 클라이언트가 푼 게임문제 검증
    */
   private async validateGameProblems(clientAnswers: ClientAnswer[]): Promise<GameProblem[]> {
-    if (clientAnswers.length === 0) {
-      return [];
-    }
-
     const problemIds = clientAnswers.map((a) => BigInt(a.problemId));
     const uniqueProblemIds = [...new Set(problemIds)];
     const problems = await this.gameRepository.findProblemsByIds(uniqueProblemIds);

--- a/src/games/application/games.service.ts
+++ b/src/games/application/games.service.ts
@@ -1,13 +1,117 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { GAME_REPOSITORY, IGameRepository } from '../domain/games.repository.interface';
 import { GameOptions } from '../domain/game-options.entity';
+import { GameProblem } from '../domain/game-problem.entity';
+import { ProblemDifficulty, calculateServerScore } from '../domain/game.business-rules';
+import { CreateGameSessionServiceRequestDto } from './service-dto/create-game-session.service-dto';
+import { ClientAnswer } from '../domain/game-client-answers.interface';
 
 @Injectable()
 export class GamesService {
   constructor(@Inject(GAME_REPOSITORY) private readonly gameRepository: IGameRepository) {}
 
+  /**
+   * @description 게임옵션(카테고리, 게임난이도) 목록 조회
+   * - 게임난이도: Easy | Normal | Hard | Random
+   */
   async getGameOptions(): Promise<GameOptions> {
     const categories = await this.gameRepository.getCategories();
     return GameOptions.from(categories);
+  }
+
+  /**
+   *
+   * @description 게임세션 저장
+   */
+  async createGameSession(command: CreateGameSessionServiceRequestDto): Promise<bigint> {
+    const serverScore = await this.validateAndCalculateScore(
+      command.categoryId,
+      command.clientAnswers,
+    );
+
+    return this.gameRepository.saveGameSession({
+      categoryId: command.categoryId,
+      difficultyMode: command.difficultyMode,
+      score: serverScore,
+      totalProblemCount: command.clientAnswers.length,
+      correctProblemCount: command.clientAnswers.filter((a) => a.solved).length,
+      logs: command.clientAnswers.map((a) => ({
+        problemId: BigInt(a.problemId),
+        inputs: a.inputs,
+        isSolved: a.solved,
+        tryCount: a.inputs.length,
+      })),
+    });
+  }
+
+  /**
+   * @description 클라이언트 게임 데이터 검증 후 서버 점수 계산
+   */
+  private async validateAndCalculateScore(
+    categoryId: number,
+    clientAnswers: ClientAnswer[],
+  ): Promise<number> {
+    await this.validateCategory(categoryId);
+    const problems = await this.validateGameProblems(clientAnswers);
+    this.validateAnswerIntegrity(clientAnswers);
+    return this.calculateScore(clientAnswers, problems);
+  }
+
+  /**
+   *
+   * @description 게임 카테고리 검증
+   */
+  private async validateCategory(categoryId: number): Promise<void> {
+    const exists = await this.gameRepository.categoryExists(categoryId);
+    if (!exists) {
+      throw new NotFoundException('존재하지 않는 카테고리입니다.');
+    }
+  }
+
+  /**
+   * @description 클라이언트가 푼 게임문제 검증
+   */
+  private async validateGameProblems(clientAnswers: ClientAnswer[]): Promise<GameProblem[]> {
+    const problemIds = clientAnswers.map((a) => BigInt(a.problemId));
+    const problems = await this.gameRepository.findProblemsByIds(problemIds);
+
+    if (problems.length !== problemIds.length) {
+      const foundIds = new Set(problems.map((p) => p.id));
+      const missingIds = problemIds.filter((id) => !foundIds.has(id));
+      throw new NotFoundException(
+        `존재하지 않는 문제 ID가 포함되어 있습니다. (problemId: ${missingIds.join(', ')})`,
+      );
+    }
+
+    return problems;
+  }
+
+  /**
+   * @description 클라이언트 문제풀이 정답/오답 검증
+   */
+  private validateAnswerIntegrity(clientAnswers: ClientAnswer[]): void {
+    const invalid = clientAnswers.find(
+      (a) => a.solved && !a.inputs.some((input) => input.isCorrect),
+    );
+    if (invalid) {
+      throw new BadRequestException(
+        '데이터 무결성 오류: solved가 true이지만 정답 처리된 입력이 없습니다.',
+      );
+    }
+  }
+
+  /**
+   * @description 클라이언트 점수 데이터가 올바르게 계산됐는지 재검증
+   */
+  private calculateScore(clientAnswers: ClientAnswer[], problems: GameProblem[]): number {
+    const problemMap = new Map(problems.map((p) => [p.id, p]));
+    const solvedDifficulties: ProblemDifficulty[] = clientAnswers
+      .filter((a) => a.solved)
+      .map((a) => {
+        const problem = problemMap.get(BigInt(a.problemId))!;
+        return problem.difficulty;
+      });
+
+    return calculateServerScore(solvedDifficulties);
   }
 }

--- a/src/games/application/service-dto/create-game-session.service-dto.ts
+++ b/src/games/application/service-dto/create-game-session.service-dto.ts
@@ -1,0 +1,9 @@
+import { ClientAnswer } from '../../domain/game-client-answers.interface';
+import { GameDifficultyMode } from '../../domain/game.business-rules';
+
+export interface CreateGameSessionServiceRequestDto {
+  categoryId: number;
+  difficultyMode: GameDifficultyMode;
+  score: number;
+  clientAnswers: ClientAnswer[];
+}

--- a/src/games/domain/game-categories.entity.ts
+++ b/src/games/domain/game-categories.entity.ts
@@ -2,9 +2,10 @@ export class GameCategory {
   private constructor(
     readonly id: number,
     readonly name: string,
+    readonly iconUrl: string,
   ) {}
 
-  static from(data: Pick<GameCategory, 'id' | 'name'>): GameCategory {
-    return new GameCategory(data.id, data.name);
+  static from(data: Pick<GameCategory, 'id' | 'name' | 'iconUrl'>): GameCategory {
+    return new GameCategory(data.id, data.name, data.iconUrl);
   }
 }

--- a/src/games/domain/game-client-answers.interface.ts
+++ b/src/games/domain/game-client-answers.interface.ts
@@ -1,0 +1,10 @@
+export interface ClientAnswerInput {
+  input: string;
+  isCorrect: boolean;
+}
+
+export interface ClientAnswer {
+  problemId: string;
+  inputs: ClientAnswerInput[];
+  solved: boolean;
+}

--- a/src/games/domain/game-problem.entity.ts
+++ b/src/games/domain/game-problem.entity.ts
@@ -1,4 +1,4 @@
-import { GameDifficultyMode } from './game.business-rules';
+import { ProblemDifficulty } from './game.business-rules';
 
 export class GameProblem {
   private constructor(
@@ -8,7 +8,7 @@ export class GameProblem {
     readonly text: string,
     readonly answer: string,
     readonly point: number,
-    readonly difficulty: GameDifficultyMode,
+    readonly difficulty: ProblemDifficulty,
   ) {}
 
   static from(

--- a/src/games/domain/game.business-rules.ts
+++ b/src/games/domain/game.business-rules.ts
@@ -24,6 +24,16 @@ export const DIFFICULTY_SCORES: Readonly<Record<ProblemDifficulty, number>> = {
   Hard: 50,
 } as const;
 
+/**
+ * 서버 측 점수 계산: solved된 문제의 난이도별 배점 합산
+ */
+export function calculateServerScore(solvedProblemDifficulties: ProblemDifficulty[]): number {
+  return solvedProblemDifficulties.reduce(
+    (total, difficulty) => total + DIFFICULTY_SCORES[difficulty],
+    0,
+  );
+}
+
 /** 게임 제한 시간 (초) - 60초 후 게임 종료 */
 export const GAME_TIMER_DURATION = 60;
 

--- a/src/games/domain/games.repository.interface.ts
+++ b/src/games/domain/games.repository.interface.ts
@@ -1,4 +1,5 @@
 import { GameCategory } from './game-categories.entity';
+import { ClientAnswerInput } from './game-client-answers.interface';
 import { GameProblem } from './game-problem.entity';
 import { GameDifficultyMode } from './game.business-rules';
 
@@ -31,4 +32,25 @@ export interface IGameRepository {
    * @description categoryId로 카테고리 존재여부 확인
    */
   categoryExists(categoryId: number): Promise<boolean>;
+  /**
+   * @description 문제 ID 목록으로 문제 조회
+   */
+  findProblemsByIds(problemIds: bigint[]): Promise<GameProblem[]>;
+  /**
+   * @description 게임 세션과 세션 로그를 원자적으로 저장
+   * @returns 생성된 GameSession ID
+   */
+  saveGameSession(data: {
+    categoryId: number;
+    difficultyMode: string;
+    score: number;
+    totalProblemCount: number;
+    correctProblemCount: number;
+    logs: {
+      problemId: bigint;
+      inputs: ClientAnswerInput[];
+      isSolved: boolean;
+      tryCount: number;
+    }[];
+  }): Promise<bigint>;
 }

--- a/src/games/domain/games.repository.interface.ts
+++ b/src/games/domain/games.repository.interface.ts
@@ -42,7 +42,7 @@ export interface IGameRepository {
    */
   saveGameSession(data: {
     categoryId: number;
-    difficultyMode: string;
+    difficultyMode: GameDifficultyMode;
     score: number;
     totalProblemCount: number;
     correctProblemCount: number;

--- a/src/games/infrastructure/games.repository.ts
+++ b/src/games/infrastructure/games.repository.ts
@@ -12,6 +12,7 @@ import {
 } from '../domain/game.business-rules';
 import { capitalize } from '@common/utils/string.util';
 import { ProblemRawRow } from './types/problem-raw-row';
+import { ClientAnswerInput } from '../domain/game-client-answers.interface';
 
 @Injectable()
 export class GameRepositoryImpl implements IGameRepository {
@@ -56,7 +57,7 @@ export class GameRepositoryImpl implements IGameRepository {
         p.title, 
         p.text, 
         p.answer, 
-        p.difficulty, 
+        p.difficulty,
         sc.name as "subCategoryName"
       FROM problems p
       JOIN sub_categories sc ON p.sub_category_id = sc.id
@@ -69,8 +70,8 @@ export class GameRepositoryImpl implements IGameRepository {
   }
 
   private mapToGameProblem(p: ProblemRawRow): GameProblem {
-    const difficulty = capitalize(p.difficulty.toLowerCase()) as GameDifficultyMode;
-    const point = DIFFICULTY_SCORES[difficulty as ProblemDifficulty];
+    const difficulty = capitalize(p.difficulty.toLowerCase()) as ProblemDifficulty;
+    const point = DIFFICULTY_SCORES[difficulty];
 
     return GameProblem.from({
       id: BigInt(p.id),
@@ -93,6 +94,73 @@ export class GameRepositoryImpl implements IGameRepository {
     });
     return category !== null;
   }
+
+  /**
+   * @description 문제 ID 목록으로 문제 조회
+   */
+  async findProblemsByIds(problemIds: bigint[]): Promise<GameProblem[]> {
+    const problems = await this.prisma.problem.findMany({
+      where: { id: { in: problemIds } },
+      include: { subCategory: { select: { name: true } } },
+    });
+
+    return problems.map((p) =>
+      this.mapToGameProblem({
+        id: p.id,
+        title: p.title,
+        text: p.text,
+        answer: p.answer,
+        difficulty: p.difficulty,
+        subCategoryName: p.subCategory.name,
+      }),
+    );
+  }
+
+  /**
+   * @description 게임 세션과 세션 로그를 원자적으로 저장
+   */
+  async saveGameSession(data: {
+    categoryId: number;
+    difficultyMode: string;
+    score: number;
+    totalProblemCount: number;
+    correctProblemCount: number;
+    logs: {
+      problemId: bigint;
+      inputs: ClientAnswerInput[];
+      isSolved: boolean;
+      tryCount: number;
+    }[];
+  }): Promise<bigint> {
+    const session = await this.prisma.$transaction(async (tx) => {
+      const gameSession = await tx.gameSession.create({
+        data: {
+          categoryId: data.categoryId,
+          difficultyMode: data.difficultyMode,
+          score: data.score,
+          totalProblemCount: data.totalProblemCount,
+          correctProblemCount: data.correctProblemCount,
+        },
+      });
+
+      if (data.logs.length > 0) {
+        await tx.gameSessionLog.createMany({
+          data: data.logs.map((log) => ({
+            sessionId: gameSession.id,
+            problemId: log.problemId,
+            inputs: log.inputs.map(({ input, isCorrect }) => ({ input, isCorrect })),
+            isSolved: log.isSolved,
+            tryCount: log.tryCount,
+          })),
+        });
+      }
+
+      return gameSession;
+    });
+
+    return session.id;
+  }
+
   /**
    * @description 모든 학습 카테고리 목록을 조회
    */

--- a/src/games/infrastructure/games.repository.ts
+++ b/src/games/infrastructure/games.repository.ts
@@ -121,7 +121,7 @@ export class GameRepositoryImpl implements IGameRepository {
    */
   async saveGameSession(data: {
     categoryId: number;
-    difficultyMode: string;
+    difficultyMode: GameDifficultyMode;
     score: number;
     totalProblemCount: number;
     correctProblemCount: number;

--- a/src/games/infrastructure/games.repository.ts
+++ b/src/games/infrastructure/games.repository.ts
@@ -2,9 +2,9 @@ import { Injectable } from '@nestjs/common';
 
 import { Prisma } from '@prisma/client';
 
+import { PrismaService } from '@/prisma/prisma.service';
 import { capitalize } from '@common/utils/string.util';
 
-import { IGameRepository, NonRandomGameDifficultyMode } from '../domain/games.repository.interface';
 import { GameCategory } from '../domain/game-categories.entity';
 import { ClientAnswerInput } from '../domain/game-client-answers.interface';
 import { GameProblem } from '../domain/game-problem.entity';
@@ -16,7 +16,11 @@ import {
   MAX_PROBLEMS_PER_GAME,
   ProblemDifficulty,
 } from '../domain/game.business-rules';
-
+import { IGameRepository, NonRandomGameDifficultyMode } from '../domain/games.repository.interface';
+import {
+  FrequentWrongCategory,
+  FrequentWrongCommand,
+} from '../domain/user-mistake-analysis.entity';
 import { ProblemRawRow } from './types/problem-raw-row';
 
 @Injectable()

--- a/src/games/infrastructure/games.repository.ts
+++ b/src/games/infrastructure/games.repository.ts
@@ -1,13 +1,12 @@
-import { Prisma } from '@prisma/client';
-import { PrismaService } from '@prisma/prisma.service';
 import { Injectable } from '@nestjs/common';
+
+import { Prisma } from '@prisma/client';
+
 import { capitalize } from '@common/utils/string.util';
-import { IGameRepository, NonRandomGameDifficultyMode } from '../domain/games.repository.interface';
+import { PrismaService } from '@prisma/prisma.service';
+
 import { GameCategory } from '../domain/game-categories.entity';
-import {
-  FrequentWrongCommand,
-  FrequentWrongCategory,
-} from '../domain/user-mistake-analysis.entity';
+import { ClientAnswerInput } from '../domain/game-client-answers.interface';
 import { GameProblem } from '../domain/game-problem.entity';
 import {
   DIFFICULTY_SCORES,
@@ -15,8 +14,12 @@ import {
   MAX_PROBLEMS_PER_GAME,
   ProblemDifficulty,
 } from '../domain/game.business-rules';
+import { IGameRepository, NonRandomGameDifficultyMode } from '../domain/games.repository.interface';
+import {
+  FrequentWrongCategory,
+  FrequentWrongCommand,
+} from '../domain/user-mistake-analysis.entity';
 import { ProblemRawRow } from './types/problem-raw-row';
-import { ClientAnswerInput } from '../domain/game-client-answers.interface';
 
 @Injectable()
 export class GameRepositoryImpl implements IGameRepository {
@@ -173,6 +176,7 @@ export class GameRepositoryImpl implements IGameRepository {
       select: {
         id: true,
         name: true,
+        iconUrl: true,
       },
       orderBy: {
         id: 'asc',

--- a/src/games/infrastructure/types/problem-raw-row.ts
+++ b/src/games/infrastructure/types/problem-raw-row.ts
@@ -1,10 +1,10 @@
-import { ProblemDifficulty } from '@games/domain/game.business-rules';
+import { Difficulty } from '@prisma/client';
 
 export interface ProblemRawRow {
   id: bigint;
   title: string;
   text: string;
   answer: string;
-  difficulty: ProblemDifficulty;
+  difficulty: Difficulty;
   subCategoryName: string;
 }

--- a/src/games/presentation/decorators/save-game-session-swagger.decorator.ts
+++ b/src/games/presentation/decorators/save-game-session-swagger.decorator.ts
@@ -1,6 +1,7 @@
 import { applyDecorators, HttpStatus } from '@nestjs/common';
 import { ApiBody, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { SaveGameSessionRequestDto } from '../dto/save-game-session.dto';
+import { MAX_PROBLEMS_PER_GAME } from '@/games/domain/game.business-rules';
 
 export function ApiSaveGameSession() {
   return applyDecorators(
@@ -8,9 +9,72 @@ export function ApiSaveGameSession() {
       summary: '게임 세션 저장',
       description: '게임 종료 후 게임 세션 결과를 저장합니다.',
     }),
-    ApiBody({ type: SaveGameSessionRequestDto }),
+    ApiBody({
+      type: SaveGameSessionRequestDto,
+      examples: {
+        '게임 결과 저장 예시': {
+          summary: '일부 정답 포함 게임 세션',
+          value: {
+            categoryId: 1,
+            difficultyMode: 'Easy',
+            score: 30,
+            clientAnswers: [
+              {
+                problemId: '73',
+                inputs: [
+                  { input: 'git branch', isCorrect: false },
+                  { input: 'git remote', isCorrect: true },
+                ],
+                solved: true,
+              },
+              {
+                problemId: '103',
+                inputs: [
+                  { input: 'git revert', isCorrect: false },
+                  { input: 'git rolback', isCorrect: false },
+                ],
+                solved: false,
+              },
+              {
+                problemId: '265',
+                inputs: [{ input: 'git tag', isCorrect: true }],
+                solved: true,
+              },
+              {
+                problemId: '134',
+                inputs: [{ input: 'git config --email "john@example.com"', isCorrect: false }],
+                solved: false,
+              },
+              { problemId: '40', inputs: [], solved: false },
+              {
+                problemId: '34',
+                inputs: [{ input: 'git branch', isCorrect: true }],
+                solved: true,
+              },
+              { problemId: '4', inputs: [], solved: false },
+              { problemId: '174', inputs: [], solved: false },
+              { problemId: '306', inputs: [], solved: false },
+              { problemId: '200', inputs: [], solved: false },
+              {
+                problemId: '237',
+                inputs: [{ input: 'git stasy', isCorrect: false }],
+                solved: false,
+              },
+              { problemId: '69', inputs: [], solved: false },
+              { problemId: '11', inputs: [], solved: false },
+              { problemId: '10', inputs: [], solved: false },
+              { problemId: '6', inputs: [], solved: false },
+              { problemId: '307', inputs: [], solved: false },
+              { problemId: '7', inputs: [], solved: false },
+              { problemId: '109', inputs: [], solved: false },
+              { problemId: '241', inputs: [], solved: false },
+            ],
+          },
+        },
+      },
+    }),
 
-    // ── 200 성공 ──
+    // ── 201 성공 ──
     ApiResponse({
       status: HttpStatus.CREATED,
       description: '게임 세션 저장 성공',
@@ -104,7 +168,7 @@ export function ApiSaveGameSession() {
               value: {
                 statusCode: 400,
                 success: false,
-                message: 'clientAnswers는 최대 20개까지 입력 가능합니다.',
+                message: `clientAnswers는 최대 ${MAX_PROBLEMS_PER_GAME}개까지 입력 가능합니다.`,
               },
             },
 

--- a/src/games/presentation/decorators/save-game-session-swagger.decorator.ts
+++ b/src/games/presentation/decorators/save-game-session-swagger.decorator.ts
@@ -1,7 +1,17 @@
-import { applyDecorators, HttpStatus } from '@nestjs/common';
-import { ApiBody, ApiOperation, ApiResponse } from '@nestjs/swagger';
-import { SaveGameSessionRequestDto } from '../dto/save-game-session.dto';
-import { MAX_PROBLEMS_PER_GAME } from '@/games/domain/game.business-rules';
+import { applyDecorators } from '@nestjs/common';
+import { ApiBody, ApiCreatedResponse, ApiOperation } from '@nestjs/swagger';
+
+import {
+  createSwaggerBadRequest,
+  createSwaggerNotFound,
+  createSwaggerServerErrors,
+} from '@common/utils/swagger-error-response.util';
+
+import { MAX_PROBLEMS_PER_GAME } from '../../domain/game.business-rules';
+import {
+  SaveGameSessionRequestDto,
+  SaveGameSessionResponseDto,
+} from '../dto/save-game-session.dto';
 
 export function ApiSaveGameSession() {
   return applyDecorators(
@@ -104,11 +114,9 @@ export function ApiSaveGameSession() {
         },
       },
     }),
-
-    // ── 201 성공 ──
-    ApiResponse({
-      status: HttpStatus.CREATED,
+    ApiCreatedResponse({
       description: '게임 세션 저장 성공',
+      type: SaveGameSessionResponseDto,
       content: {
         'application/json': {
           example: {
@@ -121,204 +129,91 @@ export function ApiSaveGameSession() {
         },
       },
     }),
-
-    // ── 400 유효성 검증 오류 ──
-    ApiResponse({
-      status: HttpStatus.BAD_REQUEST,
-      description: '유효성 검증 오류 / 데이터 무결성 오류',
-      content: {
-        'application/json': {
-          examples: {
-            // ── SaveGameSessionRequestDto ──
-            'categoryId 필수 누락': {
-              summary: 'categoryId를 보내지 않은 경우',
-              value: {
-                statusCode: 400,
-                success: false,
-                message: 'categoryId는 필수값입니다.',
-              },
-            },
-            'categoryId 타입 오류': {
-              summary: 'categoryId가 정수가 아닌 경우',
-              value: {
-                statusCode: 400,
-                success: false,
-                message: 'categoryId는 정수여야 합니다.',
-              },
-            },
-            'categoryId 범위 오류': {
-              summary: 'categoryId가 1 미만인 경우',
-              value: {
-                statusCode: 400,
-                success: false,
-                message: 'categoryId는 1 이상이어야 합니다.',
-              },
-            },
-            'difficultyMode 필수 누락': {
-              summary: 'difficultyMode를 보내지 않은 경우',
-              value: {
-                statusCode: 400,
-                success: false,
-                message: 'difficultyMode는 필수값입니다.',
-              },
-            },
-            'difficultyMode 형식 오류': {
-              summary: '유효하지 않은 난이도 모드',
-              value: {
-                statusCode: 400,
-                success: false,
-                message: 'difficultyMode는 Easy, Normal, Hard, Random 중 하나여야 합니다.',
-              },
-            },
-            'score 타입 오류': {
-              summary: 'score가 정수가 아닌 경우',
-              value: {
-                statusCode: 400,
-                success: false,
-                message: 'score는 정수여야 합니다.',
-              },
-            },
-            'score 범위 오류': {
-              summary: 'score가 0 미만인 경우',
-              value: {
-                statusCode: 400,
-                success: false,
-                message: 'score는 0 이상이어야 합니다.',
-              },
-            },
-            'clientAnswers 형식 오류': {
-              summary: 'clientAnswers가 배열이 아닌 경우',
-              value: {
-                statusCode: 400,
-                success: false,
-                message: 'clientAnswers는 배열 형식이어야 합니다.',
-              },
-            },
-            'clientAnswers 개수 초과': {
-              summary: 'clientAnswers가 최대 개수를 초과한 경우',
-              value: {
-                statusCode: 400,
-                success: false,
-                message: `clientAnswers는 최대 ${MAX_PROBLEMS_PER_GAME}개까지 입력 가능합니다.`,
-              },
-            },
-
-            // ── 비즈니스 로직 검증 (clientAnswers 개수) ──
-            'clientAnswers 개수 불일치': {
-              summary: `clientAnswers가 정확히 ${MAX_PROBLEMS_PER_GAME}개가 아닌 경우 (빈 배열 포함)`,
-              value: {
-                statusCode: 400,
-                success: false,
-                message: `clientAnswers는 ${MAX_PROBLEMS_PER_GAME}개여야 합니다.`,
-              },
-            },
-
-            // ── ClientAnswerDto ──
-            'problemId 형식 오류': {
-              summary: 'problemId가 숫자 문자열이 아닌 경우',
-              value: {
-                statusCode: 400,
-                success: false,
-                message: 'problemId는 숫자 형식의 문자열이어야 합니다.',
-              },
-            },
-            'inputs 형식 오류': {
-              summary: 'inputs가 배열이 아닌 경우',
-              value: {
-                statusCode: 400,
-                success: false,
-                message: 'inputs는 배열 형식이어야 합니다.',
-              },
-            },
-            'solved 타입 오류': {
-              summary: 'solved가 boolean이 아닌 경우',
-              value: {
-                statusCode: 400,
-                success: false,
-                message: 'solved는 boolean 타입이어야 합니다.',
-              },
-            },
-
-            // ── InputDto ──
-            'input 타입 오류': {
-              summary: 'input이 문자열이 아닌 경우',
-              value: {
-                statusCode: 400,
-                success: false,
-                message: 'input은 문자열이어야 합니다.',
-              },
-            },
-            'input 필수 누락': {
-              summary: 'input이 빈 문자열인 경우',
-              value: {
-                statusCode: 400,
-                success: false,
-                message: 'input은 필수값입니다.',
-              },
-            },
-            'input 길이 초과': {
-              summary: 'input이 255자를 초과한 경우',
-              value: {
-                statusCode: 400,
-                success: false,
-                message: 'input은 최대 255자까지 입력 가능합니다.',
-              },
-            },
-            'isCorrect 타입 오류': {
-              summary: 'isCorrect가 boolean이 아닌 경우',
-              value: {
-                statusCode: 400,
-                success: false,
-                message: 'isCorrect는 boolean 타입이어야 합니다.',
-              },
-            },
-
-            // ── 비즈니스 로직 검증 ──
-            '데이터 무결성 오류': {
-              summary: 'solved=true인데 정답 처리된 입력(isCorrect=true)이 없는 경우',
-              value: {
-                statusCode: 400,
-                success: false,
-                message: '데이터 무결성 오류: solved가 true이지만 정답 처리된 입력이 없습니다.',
-              },
-            },
-          },
-        },
+    createSwaggerBadRequest([
+      {
+        description: 'categoryId를 보내지 않은 경우',
+        message: 'categoryId는 필수값입니다.',
       },
-    }),
-
-    // ── 404 리소스 없음 ──
-    ApiResponse({
-      status: HttpStatus.NOT_FOUND,
-      description: '리소스를 찾을 수 없음',
-      content: {
-        'application/json': {
-          examples: {
-            '존재하지 않는 카테고리': {
-              summary: 'DB에 존재하지 않는 categoryId',
-              value: {
-                statusCode: 404,
-                success: false,
-                message: '존재하지 않는 카테고리입니다.',
-              },
-            },
-            '존재하지 않는 문제 ID': {
-              summary: 'DB에 존재하지 않는 problemId 포함',
-              value: {
-                statusCode: 404,
-                success: false,
-                message: '존재하지 않는 문제 ID가 포함되어 있습니다. (problemId: 999)',
-              },
-            },
-          },
-        },
+      {
+        description: 'categoryId가 정수가 아닌 경우',
+        message: 'categoryId는 정수여야 합니다.',
       },
-    }),
+      {
+        description: 'categoryId가 1 미만인 경우',
+        message: 'categoryId는 1 이상이어야 합니다.',
+      },
+      {
+        description: 'difficultyMode를 보내지 않은 경우',
+        message: 'difficultyMode는 필수값입니다.',
+      },
+      {
+        description: '유효하지 않은 난이도 모드',
+        message: 'difficultyMode는 Easy, Normal, Hard, Random 중 하나여야 합니다.',
+      },
+      {
+        description: 'score가 정수가 아닌 경우',
+        message: 'score는 정수여야 합니다.',
+      },
+      {
+        description: 'score가 0 미만인 경우',
+        message: 'score는 0 이상이어야 합니다.',
+      },
+      {
+        description: 'clientAnswers가 배열이 아닌 경우',
+        message: 'clientAnswers는 배열 형식이어야 합니다.',
+      },
+      {
+        description: `clientAnswers가 정확히 ${MAX_PROBLEMS_PER_GAME}개가 아닌 경우 (빈 배열 포함)`,
+        message: `clientAnswers는 정확히 ${MAX_PROBLEMS_PER_GAME}개여야 합니다.`,
+      },
+      {
+        description: 'problemId가 숫자 문자열이 아닌 경우',
+        message: 'problemId는 숫자 형식의 문자열이어야 합니다.',
+      },
+      {
+        description: 'inputs가 배열이 아닌 경우',
+        message: 'inputs는 배열 형식이어야 합니다.',
+      },
+      {
+        description: 'solved가 boolean이 아닌 경우',
+        message: 'solved는 boolean 타입이어야 합니다.',
+      },
+      {
+        description: 'input이 문자열이 아닌 경우',
+        message: 'input은 문자열이어야 합니다.',
+      },
+      {
+        description: 'input이 빈 문자열인 경우',
+        message: 'input은 필수값입니다.',
+      },
+      {
+        description: 'input이 255자를 초과한 경우',
+        message: 'input은 최대 255자까지 입력 가능합니다.',
+      },
+      {
+        description: 'isCorrect가 boolean이 아닌 경우',
+        message: 'isCorrect는 boolean 타입이어야 합니다.',
+      },
+      {
+        description: 'solved=true인데 정답 처리된 입력(isCorrect=true)이 없는 경우',
+        message: '데이터 무결성 오류: solved가 true이지만 정답 처리된 입력이 없습니다.',
+      },
+      {
+        description: 'clientAnswers에 동일한 problemId가 2개 이상 포함된 경우',
+        message: 'clientAnswers에 중복된 problemId가 포함되어 있습니다.',
+      },
+    ]),
+    createSwaggerNotFound([
+      {
+        description: 'DB에 존재하지 않는 categoryId',
+        message: '존재하지 않는 카테고리입니다.',
+      },
+      {
+        description: 'DB에 존재하지 않는 problemId 포함',
+        message: '존재하지 않는 문제 ID가 포함되어 있습니다.',
+      },
+    ]),
 
-    // ── 500 서버 오류 ──
-    ApiResponse({
-      status: HttpStatus.INTERNAL_SERVER_ERROR,
-      description: 'Internal Server Error',
-    }),
+    ...createSwaggerServerErrors(),
   );
 }

--- a/src/games/presentation/decorators/save-game-session-swagger.decorator.ts
+++ b/src/games/presentation/decorators/save-game-session-swagger.decorator.ts
@@ -1,0 +1,219 @@
+import { applyDecorators, HttpStatus } from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { SaveGameSessionRequestDto } from '../dto/save-game-session.dto';
+
+export function ApiSaveGameSession() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '게임 세션 저장',
+      description: '게임 종료 후 게임 세션 결과를 저장합니다.',
+    }),
+    ApiBody({ type: SaveGameSessionRequestDto }),
+
+    // ── 200 성공 ──
+    ApiResponse({
+      status: HttpStatus.CREATED,
+      description: '게임 세션 저장 성공',
+      content: {
+        'application/json': {
+          example: {
+            statusCode: 201,
+            success: true,
+            data: {
+              gameSessionId: '1',
+            },
+          },
+        },
+      },
+    }),
+
+    // ── 400 유효성 검증 오류 ──
+    ApiResponse({
+      status: HttpStatus.BAD_REQUEST,
+      description: '유효성 검증 오류 / 데이터 무결성 오류',
+      content: {
+        'application/json': {
+          examples: {
+            // ── SaveGameSessionRequestDto ──
+            'categoryId 필수 누락': {
+              summary: 'categoryId를 보내지 않은 경우',
+              value: {
+                statusCode: 400,
+                success: false,
+                message: 'categoryId는 필수값입니다.',
+              },
+            },
+            'categoryId 타입 오류': {
+              summary: 'categoryId가 정수가 아닌 경우',
+              value: {
+                statusCode: 400,
+                success: false,
+                message: 'categoryId는 정수여야 합니다.',
+              },
+            },
+            'categoryId 범위 오류': {
+              summary: 'categoryId가 1 미만인 경우',
+              value: {
+                statusCode: 400,
+                success: false,
+                message: 'categoryId는 1 이상이어야 합니다.',
+              },
+            },
+            'difficultyMode 필수 누락': {
+              summary: 'difficultyMode를 보내지 않은 경우',
+              value: {
+                statusCode: 400,
+                success: false,
+                message: 'difficultyMode는 필수값입니다.',
+              },
+            },
+            'difficultyMode 형식 오류': {
+              summary: '유효하지 않은 난이도 모드',
+              value: {
+                statusCode: 400,
+                success: false,
+                message: 'difficultyMode는 Easy, Normal, Hard, Random 중 하나여야 합니다.',
+              },
+            },
+            'score 타입 오류': {
+              summary: 'score가 정수가 아닌 경우',
+              value: {
+                statusCode: 400,
+                success: false,
+                message: 'score는 정수여야 합니다.',
+              },
+            },
+            'score 범위 오류': {
+              summary: 'score가 0 미만인 경우',
+              value: {
+                statusCode: 400,
+                success: false,
+                message: 'score는 0 이상이어야 합니다.',
+              },
+            },
+            'clientAnswers 형식 오류': {
+              summary: 'clientAnswers가 배열이 아닌 경우',
+              value: {
+                statusCode: 400,
+                success: false,
+                message: 'clientAnswers는 배열 형식이어야 합니다.',
+              },
+            },
+            'clientAnswers 개수 초과': {
+              summary: 'clientAnswers가 최대 개수를 초과한 경우',
+              value: {
+                statusCode: 400,
+                success: false,
+                message: 'clientAnswers는 최대 20개까지 입력 가능합니다.',
+              },
+            },
+
+            // ── ClientAnswerDto ──
+            'problemId 형식 오류': {
+              summary: 'problemId가 숫자 문자열이 아닌 경우',
+              value: {
+                statusCode: 400,
+                success: false,
+                message: 'problemId는 숫자 형식의 문자열이어야 합니다.',
+              },
+            },
+            'inputs 형식 오류': {
+              summary: 'inputs가 배열이 아닌 경우',
+              value: {
+                statusCode: 400,
+                success: false,
+                message: 'inputs는 배열 형식이어야 합니다.',
+              },
+            },
+            'solved 타입 오류': {
+              summary: 'solved가 boolean이 아닌 경우',
+              value: {
+                statusCode: 400,
+                success: false,
+                message: 'solved는 boolean 타입이어야 합니다.',
+              },
+            },
+
+            // ── InputDto ──
+            'input 타입 오류': {
+              summary: 'input이 문자열이 아닌 경우',
+              value: {
+                statusCode: 400,
+                success: false,
+                message: 'input은 문자열이어야 합니다.',
+              },
+            },
+            'input 필수 누락': {
+              summary: 'input이 빈 문자열인 경우',
+              value: {
+                statusCode: 400,
+                success: false,
+                message: 'input은 필수값입니다.',
+              },
+            },
+            'input 길이 초과': {
+              summary: 'input이 255자를 초과한 경우',
+              value: {
+                statusCode: 400,
+                success: false,
+                message: 'input은 최대 255자까지 입력 가능합니다.',
+              },
+            },
+            'isCorrect 타입 오류': {
+              summary: 'isCorrect가 boolean이 아닌 경우',
+              value: {
+                statusCode: 400,
+                success: false,
+                message: 'isCorrect는 boolean 타입이어야 합니다.',
+              },
+            },
+
+            // ── 비즈니스 로직 검증 ──
+            '데이터 무결성 오류': {
+              summary: 'solved=true인데 정답 처리된 입력(isCorrect=true)이 없는 경우',
+              value: {
+                statusCode: 400,
+                success: false,
+                message: '데이터 무결성 오류: solved가 true이지만 정답 처리된 입력이 없습니다.',
+              },
+            },
+          },
+        },
+      },
+    }),
+
+    // ── 404 리소스 없음 ──
+    ApiResponse({
+      status: HttpStatus.NOT_FOUND,
+      description: '리소스를 찾을 수 없음',
+      content: {
+        'application/json': {
+          examples: {
+            '존재하지 않는 카테고리': {
+              summary: 'DB에 존재하지 않는 categoryId',
+              value: {
+                statusCode: 404,
+                success: false,
+                message: '존재하지 않는 카테고리입니다.',
+              },
+            },
+            '존재하지 않는 문제 ID': {
+              summary: 'DB에 존재하지 않는 problemId 포함',
+              value: {
+                statusCode: 404,
+                success: false,
+                message: '존재하지 않는 문제 ID가 포함되어 있습니다. (problemId: 999)',
+              },
+            },
+          },
+        },
+      },
+    }),
+
+    // ── 500 서버 오류 ──
+    ApiResponse({
+      status: HttpStatus.INTERNAL_SERVER_ERROR,
+      description: 'Internal Server Error',
+    }),
+  );
+}

--- a/src/games/presentation/decorators/save-game-session-swagger.decorator.ts
+++ b/src/games/presentation/decorators/save-game-session-swagger.decorator.ts
@@ -12,8 +12,8 @@ export function ApiSaveGameSession() {
     ApiBody({
       type: SaveGameSessionRequestDto,
       examples: {
-        '게임 결과 저장 예시': {
-          summary: '일부 정답 포함 게임 세션',
+        '일부 정답 포함': {
+          summary: '일부 문제를 맞춘 게임 세션',
           value: {
             categoryId: 1,
             difficultyMode: 'Easy',
@@ -68,6 +68,37 @@ export function ApiSaveGameSession() {
               { problemId: '7', inputs: [], solved: false },
               { problemId: '109', inputs: [], solved: false },
               { problemId: '241', inputs: [], solved: false },
+              { problemId: '43', inputs: [], solved: false },
+            ],
+          },
+        },
+        '모두 오답': {
+          summary: '아무것도 풀지 않은 게임 세션',
+          value: {
+            categoryId: 1,
+            difficultyMode: 'Easy',
+            score: 0,
+            clientAnswers: [
+              { problemId: '103', inputs: [], solved: false },
+              { problemId: '136', inputs: [], solved: false },
+              { problemId: '207', inputs: [], solved: false },
+              { problemId: '273', inputs: [], solved: false },
+              { problemId: '143', inputs: [], solved: false },
+              { problemId: '40', inputs: [], solved: false },
+              { problemId: '176', inputs: [], solved: false },
+              { problemId: '109', inputs: [], solved: false },
+              { problemId: '41', inputs: [], solved: false },
+              { problemId: '265', inputs: [], solved: false },
+              { problemId: '275', inputs: [], solved: false },
+              { problemId: '11', inputs: [], solved: false },
+              { problemId: '168', inputs: [], solved: false },
+              { problemId: '9', inputs: [], solved: false },
+              { problemId: '142', inputs: [], solved: false },
+              { problemId: '242', inputs: [], solved: false },
+              { problemId: '110', inputs: [], solved: false },
+              { problemId: '201', inputs: [], solved: false },
+              { problemId: '42', inputs: [], solved: false },
+              { problemId: '43', inputs: [], solved: false },
             ],
           },
         },
@@ -169,6 +200,16 @@ export function ApiSaveGameSession() {
                 statusCode: 400,
                 success: false,
                 message: `clientAnswers는 최대 ${MAX_PROBLEMS_PER_GAME}개까지 입력 가능합니다.`,
+              },
+            },
+
+            // ── 비즈니스 로직 검증 (clientAnswers 개수) ──
+            'clientAnswers 개수 불일치': {
+              summary: `clientAnswers가 정확히 ${MAX_PROBLEMS_PER_GAME}개가 아닌 경우 (빈 배열 포함)`,
+              value: {
+                statusCode: 400,
+                success: false,
+                message: `clientAnswers는 ${MAX_PROBLEMS_PER_GAME}개여야 합니다.`,
               },
             },
 

--- a/src/games/presentation/dto/save-game-session.dto.ts
+++ b/src/games/presentation/dto/save-game-session.dto.ts
@@ -105,9 +105,11 @@ export class SaveGameSessionRequestDto {
     type: [ClientAnswerDto],
   })
   @IsArray({ message: 'clientAnswers는 배열 형식이어야 합니다.' })
-  @ArrayMinSize(0)
+  @ArrayMinSize(MAX_PROBLEMS_PER_GAME, {
+    message: `clientAnswers는 정확히 ${MAX_PROBLEMS_PER_GAME}개여야 합니다.`,
+  })
   @ArrayMaxSize(MAX_PROBLEMS_PER_GAME, {
-    message: `clientAnswers는 최대 ${MAX_PROBLEMS_PER_GAME}개까지 입력 가능합니다.`,
+    message: `clientAnswers는 정확히 ${MAX_PROBLEMS_PER_GAME}개여야 합니다.`,
   })
   @ValidateNested({ each: true })
   @Type(() => ClientAnswerDto)

--- a/src/games/presentation/dto/save-game-session.dto.ts
+++ b/src/games/presentation/dto/save-game-session.dto.ts
@@ -1,0 +1,123 @@
+import {
+  DIFFICULTY_MODES,
+  GameDifficultyMode,
+  MAX_PROBLEMS_PER_GAME,
+} from '@games/domain/game.business-rules';
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsNumberString,
+  IsString,
+  MaxLength,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+
+export class InputDto {
+  @ApiProperty({
+    description: '사용자 입력 값',
+    example: 'git commit -m',
+  })
+  @IsString({ message: 'input은 문자열이어야 합니다.' })
+  @IsNotEmpty({ message: 'input은 필수값입니다.' })
+  @MaxLength(255, { message: 'input은 최대 255자까지 입력 가능합니다.' })
+  input: string;
+
+  @ApiProperty({
+    description: '정답 여부',
+    example: false,
+  })
+  @IsBoolean({ message: 'isCorrect는 boolean 타입이어야 합니다.' })
+  isCorrect: boolean;
+}
+
+export class ClientAnswerDto {
+  @ApiProperty({
+    description: '문제 ID',
+    example: '1',
+  })
+  @IsNumberString({}, { message: 'problemId는 숫자 형식의 문자열이어야 합니다.' })
+  problemId: string;
+
+  @ApiProperty({
+    description: '사용자 입력 이력',
+    type: [InputDto],
+  })
+  @IsArray({ message: 'inputs는 배열 형식이어야 합니다.' })
+  @ArrayMinSize(0)
+  @ValidateNested({ each: true })
+  @Type(() => InputDto)
+  inputs: InputDto[];
+
+  @ApiProperty({
+    description: '문제 해결 여부',
+    example: true,
+  })
+  @IsBoolean({ message: 'solved는 boolean 타입이어야 합니다.' })
+  solved: boolean;
+}
+
+export class SaveGameSessionRequestDto {
+  @ApiProperty({
+    description: '카테고리 ID',
+    required: true,
+    example: 1,
+  })
+  @IsNotEmpty({ message: 'categoryId는 필수값입니다.' })
+  @IsInt({ message: 'categoryId는 정수여야 합니다.' })
+  @Min(1, { message: 'categoryId는 1 이상이어야 합니다.' })
+  @Type(() => Number)
+  categoryId: number;
+
+  @ApiProperty({
+    description: '난이도 모드',
+    enum: DIFFICULTY_MODES,
+    required: true,
+    example: 'Normal',
+  })
+  @IsNotEmpty({ message: 'difficultyMode는 필수값입니다.' })
+  @IsEnum(GameDifficultyMode, {
+    message: 'difficultyMode는 Easy, Normal, Hard, Random 중 하나여야 합니다.',
+  })
+  difficultyMode: GameDifficultyMode;
+
+  @ApiProperty({
+    description: '획득 점수',
+    required: true,
+    example: 150,
+  })
+  @IsInt({ message: 'score는 정수여야 합니다.' })
+  @Min(0, { message: 'score는 0 이상이어야 합니다.' })
+  score: number;
+
+  @ApiProperty({
+    description: '클라이언트 답안 목록',
+    required: true,
+    type: [ClientAnswerDto],
+  })
+  @IsArray({ message: 'clientAnswers는 배열 형식이어야 합니다.' })
+  @ArrayMinSize(0)
+  @ArrayMaxSize(MAX_PROBLEMS_PER_GAME, {
+    message: `clientAnswers는 최대 ${MAX_PROBLEMS_PER_GAME}개까지 입력 가능합니다.`,
+  })
+  @ValidateNested({ each: true })
+  @Type(() => ClientAnswerDto)
+  clientAnswers: ClientAnswerDto[];
+}
+
+export class SaveGameSessionResponseDto {
+  gameSessionId: string;
+
+  static from(gameSessionId: bigint): SaveGameSessionResponseDto {
+    const dto = new SaveGameSessionResponseDto();
+    dto.gameSessionId = gameSessionId.toString();
+    return dto;
+  }
+}

--- a/src/games/presentation/dto/save-game-session.dto.ts
+++ b/src/games/presentation/dto/save-game-session.dto.ts
@@ -1,10 +1,6 @@
-import {
-  DIFFICULTY_MODES,
-  GameDifficultyMode,
-  MAX_PROBLEMS_PER_GAME,
-} from '@games/domain/game.business-rules';
 import { ApiProperty } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
+
+import { plainToInstance, Type } from 'class-transformer';
 import {
   ArrayMaxSize,
   ArrayMinSize,
@@ -19,6 +15,12 @@ import {
   Min,
   ValidateNested,
 } from 'class-validator';
+
+import {
+  DIFFICULTY_MODES,
+  GameDifficultyMode,
+  MAX_PROBLEMS_PER_GAME,
+} from '../../domain/game.business-rules';
 
 export class InputDto {
   @ApiProperty({
@@ -113,11 +115,14 @@ export class SaveGameSessionRequestDto {
 }
 
 export class SaveGameSessionResponseDto {
+  @ApiProperty({
+    description: '생성된 게임세션 ID',
+  })
   gameSessionId: string;
 
   static from(gameSessionId: bigint): SaveGameSessionResponseDto {
-    const dto = new SaveGameSessionResponseDto();
-    dto.gameSessionId = gameSessionId.toString();
-    return dto;
+    return plainToInstance(SaveGameSessionResponseDto, {
+      gameSessionId: String(gameSessionId),
+    });
   }
 }

--- a/src/games/presentation/games.controller.spec.ts
+++ b/src/games/presentation/games.controller.spec.ts
@@ -1,17 +1,18 @@
+import { EventEmitter } from 'events';
+import { BadRequestException, Logger, MessageEvent, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { GamesController } from './games.controller';
+
+import { Request, Response } from 'express';
+import { Observable, of, Subject, takeUntil } from 'rxjs';
+
+import { GameStreamService } from '../application/game-stream.service';
 import { GamesService } from '../application/games.service';
 import { GameCategory } from '../domain/game-categories.entity';
 import { GameOptions } from '../domain/game-options.entity';
-import { DIFFICULTY_MODES } from '../domain/game.business-rules';
+import { DIFFICULTY_MODES, GameDifficultyMode } from '../domain/game.business-rules';
 import { GetGameOptionsResponseDto } from './dto/get-game-options.dto';
-import { GameStreamService } from '../application/game-stream.service';
-import { GameDifficultyMode } from '../domain/game.business-rules';
-import { EventEmitter } from 'events';
-import { Observable, of, Subject, takeUntil } from 'rxjs';
-import { BadRequestException, Logger, MessageEvent, NotFoundException } from '@nestjs/common';
-import { Request, Response } from 'express';
 import { ClientAnswerDto, InputDto, SaveGameSessionRequestDto } from './dto/save-game-session.dto';
+import { GamesController } from './games.controller';
 
 describe('GamesController', () => {
   let controller: GamesController;
@@ -50,9 +51,9 @@ describe('GamesController', () => {
   describe('getGameOptions', () => {
     it('게임옵션 정보를 정상적으로 응답한다.', async () => {
       const categories: GameCategory[] = [
-        { id: 1, name: 'Git' },
-        { id: 2, name: 'Linux' },
-        { id: 3, name: 'Docker' },
+        { id: 1, name: 'Git', iconUrl: 'https://fake-storage/categories/git.png' },
+        { id: 2, name: 'Linux', iconUrl: 'https://fake-storage/categories/linux.png' },
+        { id: 3, name: 'Docker', iconUrl: 'https://fake-storage/categories/docker.png' },
       ];
       const gameOptions = GameOptions.from(categories);
       gameService.getGameOptions.mockResolvedValue(gameOptions);
@@ -224,6 +225,15 @@ describe('GamesController', () => {
         );
 
         await expect(controller.saveGameSession(dto)).rejects.toThrow(NotFoundException);
+      });
+
+      it('중복된 problemId가 포함되어 있으면 BadRequestException을 던진다.', async () => {
+        const dto = createDto();
+        gameService.createGameSession.mockRejectedValue(
+          new BadRequestException('clientAnswers에 중복된 problemId가 포함되어 있습니다.'),
+        );
+
+        await expect(controller.saveGameSession(dto)).rejects.toThrow(BadRequestException);
       });
 
       it('존재하지 않는 문제 ID가 포함되어 있으면 NotFoundException을 던진다.', async () => {

--- a/src/games/presentation/games.controller.spec.ts
+++ b/src/games/presentation/games.controller.spec.ts
@@ -1,28 +1,29 @@
 import { EventEmitter } from 'events';
 import { BadRequestException, Logger, MessageEvent, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { Logger, MessageEvent, NotFoundException } from '@nestjs/common';
-import { EventEmitter } from 'events';
-import { Observable, of, Subject, takeUntil } from 'rxjs';
+
 import { Request, Response } from 'express';
+import { Observable, of, Subject, takeUntil } from 'rxjs';
 
-import { GamesController } from './games.controller';
-
-import { GamesService } from '../application/games.service';
-import { GameStreamService } from '../application/game-stream.service';
 import { GameSessionService } from '../application/game-session.service';
-
+import { GameStreamService } from '../application/game-stream.service';
+import { GamesService } from '../application/games.service';
 import { GameCategory } from '../domain/game-categories.entity';
 import { GameOptions } from '../domain/game-options.entity';
 import { GameSessionHistoryList } from '../domain/game-session-history.entity';
-import { DIFFICULTY_MODES, GameSessionSortBy, SortOrder } from '../domain/game.business-rules';
-import { GameDifficultyMode } from '../domain/game.business-rules';
-
-import { GetGameOptionsResponseDto } from './dto/get-game-options.dto';
+import {
+  DIFFICULTY_MODES,
+  GameDifficultyMode,
+  GameSessionSortBy,
+  SortOrder,
+} from '../domain/game.business-rules';
 import {
   GetGameHistoriesQueryDto,
   GetGameHistoriesResponseDto,
 } from './dto/get-game-histories.dto';
+import { GetGameOptionsResponseDto } from './dto/get-game-options.dto';
+import { ClientAnswerDto, InputDto, SaveGameSessionRequestDto } from './dto/save-game-session.dto';
+import { GamesController } from './games.controller';
 
 describe('GamesController', () => {
   let controller: GamesController;

--- a/src/games/presentation/games.controller.spec.ts
+++ b/src/games/presentation/games.controller.spec.ts
@@ -9,8 +9,9 @@ import { GameStreamService } from '../application/game-stream.service';
 import { GameDifficultyMode } from '../domain/game.business-rules';
 import { EventEmitter } from 'events';
 import { Observable, of, Subject, takeUntil } from 'rxjs';
-import { Logger, MessageEvent, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Logger, MessageEvent, NotFoundException } from '@nestjs/common';
 import { Request, Response } from 'express';
+import { ClientAnswerDto, InputDto, SaveGameSessionRequestDto } from './dto/save-game-session.dto';
 
 describe('GamesController', () => {
   let controller: GamesController;
@@ -20,6 +21,7 @@ describe('GamesController', () => {
   beforeEach(async () => {
     const mockGameService = {
       getGameOptions: jest.fn(),
+      createGameSession: jest.fn(),
     };
     const mockGameStreamService = {
       validateGameStreamParams: jest.fn(),
@@ -175,6 +177,73 @@ describe('GamesController', () => {
         expect(mockResponse.end).toHaveBeenCalled();
 
         loggerSpy.mockRestore();
+      });
+    });
+  });
+  describe('saveGameSession', () => {
+    const createDto = (): SaveGameSessionRequestDto => {
+      const input = Object.assign(new InputDto(), {
+        input: 'git init',
+        isCorrect: true,
+      });
+      const clientAnswer = Object.assign(new ClientAnswerDto(), {
+        problemId: '1',
+        inputs: [input],
+        solved: true,
+      });
+      return Object.assign(new SaveGameSessionRequestDto(), {
+        categoryId: 1,
+        difficultyMode: GameDifficultyMode.Easy,
+        score: 10,
+        clientAnswers: [clientAnswer],
+      });
+    };
+
+    describe('✅ 성공 케이스', () => {
+      it('게임 세션을 정상 저장하고 gameSessionId를 반환한다.', async () => {
+        const dto = createDto();
+        gameService.createGameSession.mockResolvedValue(BigInt(100));
+
+        const result = await controller.saveGameSession(dto);
+
+        expect(result).toEqual({ gameSessionId: '100' });
+        expect(gameService.createGameSession).toHaveBeenCalledWith({
+          categoryId: dto.categoryId,
+          difficultyMode: dto.difficultyMode,
+          score: dto.score,
+          clientAnswers: dto.clientAnswers,
+        });
+      });
+    });
+    describe('❌ 실패 케이스', () => {
+      it('존재하지 않는 카테고리면 NotFoundException을 던진다.', async () => {
+        const dto = createDto();
+        dto.categoryId = 999;
+        gameService.createGameSession.mockRejectedValue(
+          new NotFoundException('존재하지 않는 카테고리입니다.'),
+        );
+
+        await expect(controller.saveGameSession(dto)).rejects.toThrow(NotFoundException);
+      });
+
+      it('존재하지 않는 문제 ID가 포함되어 있으면 NotFoundException을 던진다.', async () => {
+        const dto = createDto();
+        gameService.createGameSession.mockRejectedValue(
+          new NotFoundException('존재하지 않는 문제 ID가 포함되어 있습니다. (problemId: 999)'),
+        );
+
+        await expect(controller.saveGameSession(dto)).rejects.toThrow(NotFoundException);
+      });
+
+      it('solved=true인데 정답 처리된 입력이 없으면 BadRequestException을 던진다.', async () => {
+        const dto = createDto();
+        gameService.createGameSession.mockRejectedValue(
+          new BadRequestException(
+            '데이터 무결성 오류: solved가 true이지만 정답 처리된 입력이 없습니다.',
+          ),
+        );
+
+        await expect(controller.saveGameSession(dto)).rejects.toThrow(BadRequestException);
       });
     });
   });

--- a/src/games/presentation/games.controller.ts
+++ b/src/games/presentation/games.controller.ts
@@ -1,22 +1,22 @@
 import { Body, Controller, Get, Logger, MessageEvent, Post, Query, Req, Res } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
+
 import { Request, Response } from 'express';
 import { Subject } from 'rxjs';
 
-import { GamesService } from '../application/games.service';
-import { GameStreamService } from '../application/game-stream.service';
 import { GameSessionService } from '../application/game-session.service';
-
-import { GetGameOptionsResponseDto } from './dto/get-game-options.dto';
+import { GameStreamService } from '../application/game-stream.service';
+import { GamesService } from '../application/games.service';
+import { ApiGameStream } from './decorators/game-stream-swagger.decorator';
+import { ApiGetGameHistories } from './decorators/get-game-histories-swagger.decorator';
+import { ApiGetGameOptions } from './decorators/get-game-options-swagger.decorator';
+import { ApiSaveGameSession } from './decorators/save-game-session-swagger.decorator';
 import { GameStreamQueryDto } from './dto/game-stream-query.dto';
 import {
   GetGameHistoriesQueryDto,
   GetGameHistoriesResponseDto,
 } from './dto/get-game-histories.dto';
-
-import { ApiGetGameOptions } from './decorators/get-game-options-swagger.decorator';
-import { ApiGetGameHistories } from './decorators/get-game-histories-swagger.decorator';
-import { ApiGameStream } from './decorators/game-stream-swagger.decorator';
+import { GetGameOptionsResponseDto } from './dto/get-game-options.dto';
 import { SaveGameSessionRequestDto, SaveGameSessionResponseDto } from './dto/save-game-session.dto';
 
 @ApiTags('Games')
@@ -107,7 +107,7 @@ export class GamesController {
     // 회원인경우에는 totalScore도 같이 리스폰스하도록 응답DTO(SaveGameSessionResponseDto) 업데이트
     return SaveGameSessionResponseDto.from(gameSessionId);
   }
-  
+
   @Get('sessions')
   @ApiGetGameHistories()
   async getGameHistories(

--- a/src/games/presentation/games.controller.ts
+++ b/src/games/presentation/games.controller.ts
@@ -1,13 +1,15 @@
-import { Controller, Get, Logger, MessageEvent, Query, Req, Res } from '@nestjs/common';
+import { Body, Controller, Get, Logger, MessageEvent, Post, Query, Req, Res } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { GamesService } from '../application/games.service';
 import { GetGameOptionsResponseDto } from './dto/get-game-options.dto';
 import { ApiGetGameOptions } from './decorators/get-game-options-swagger.decorator';
 import { ApiGameStream } from './decorators/game-stream-swagger.decorator';
+import { ApiSaveGameSession } from './decorators/save-game-session-swagger.decorator';
 import { Request, Response } from 'express';
 import { Subject } from 'rxjs';
 import { GameStreamService } from '../application/game-stream.service';
 import { GameStreamQueryDto } from './dto/game-stream-query.dto';
+import { SaveGameSessionRequestDto, SaveGameSessionResponseDto } from './dto/save-game-session.dto';
 
 @ApiTags('Games')
 @Controller('games')
@@ -75,5 +77,20 @@ export class GamesController {
         response.end();
       },
     });
+  }
+
+  @Post('save')
+  @ApiSaveGameSession()
+  async saveGameSession(
+    @Body() dto: SaveGameSessionRequestDto,
+  ): Promise<SaveGameSessionResponseDto> {
+    const gameSessionId = await this.gameService.createGameSession({
+      categoryId: dto.categoryId,
+      difficultyMode: dto.difficultyMode,
+      score: dto.score,
+      clientAnswers: dto.clientAnswers,
+    });
+
+    return SaveGameSessionResponseDto.from(gameSessionId);
   }
 }

--- a/src/games/presentation/games.controller.ts
+++ b/src/games/presentation/games.controller.ts
@@ -1,14 +1,16 @@
 import { Body, Controller, Get, Logger, MessageEvent, Post, Query, Req, Res } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { GamesService } from '../application/games.service';
-import { GetGameOptionsResponseDto } from './dto/get-game-options.dto';
-import { ApiGetGameOptions } from './decorators/get-game-options-swagger.decorator';
-import { ApiGameStream } from './decorators/game-stream-swagger.decorator';
-import { ApiSaveGameSession } from './decorators/save-game-session-swagger.decorator';
+
 import { Request, Response } from 'express';
 import { Subject } from 'rxjs';
+
 import { GameStreamService } from '../application/game-stream.service';
+import { GamesService } from '../application/games.service';
+import { ApiGameStream } from './decorators/game-stream-swagger.decorator';
+import { ApiGetGameOptions } from './decorators/get-game-options-swagger.decorator';
+import { ApiSaveGameSession } from './decorators/save-game-session-swagger.decorator';
 import { GameStreamQueryDto } from './dto/game-stream-query.dto';
+import { GetGameOptionsResponseDto } from './dto/get-game-options.dto';
 import { SaveGameSessionRequestDto, SaveGameSessionResponseDto } from './dto/save-game-session.dto';
 
 @ApiTags('Games')
@@ -91,6 +93,10 @@ export class GamesController {
       clientAnswers: dto.clientAnswers,
     });
 
+    // FIXME: (회원 한정) 게임세션 저장후
+    // user 도메인이 연관되므로 Facade application 계층 추가
+    // user_id에 매핑된 게임세션들의 score들을 합산하여 User.totalScore 업데이트
+    // 회원인경우에는 totalScore도 같이 리스폰스하도록 응답DTO(SaveGameSessionResponseDto) 업데이트
     return SaveGameSessionResponseDto.from(gameSessionId);
   }
 }

--- a/test/games/save-game-session.e2e-spec.ts
+++ b/test/games/save-game-session.e2e-spec.ts
@@ -173,22 +173,6 @@ describe('POST /api/games/save (e2e)', () => {
       expect(body.success).toBe(true);
       expect(body.data.gameSessionId).toBeDefined();
     });
-
-    it('clientAnswers가 빈 배열이어도 게임 세션을 저장한다.', async () => {
-      const response = await request(app.getHttpServer())
-        .post('/api/games/save')
-        .send({
-          categoryId: 1,
-          difficultyMode: 'Random',
-          score: 0,
-          clientAnswers: [],
-        })
-        .expect(201);
-
-      const body = response.body as SuccessResponse;
-      expect(body.success).toBe(true);
-      expect(body.data.gameSessionId).toBeDefined();
-    });
   });
 
   describe('❌ 실패 케이스 - RequestBody 유효성 검증', () => {
@@ -336,6 +320,22 @@ describe('POST /api/games/save (e2e)', () => {
   });
 
   describe('❌ 실패 케이스 - 비즈니스 로직 검증', () => {
+    it('clientAnswers가 빈 배열이면 400 에러를 응답한다.', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/api/games/save')
+        .send({
+          categoryId: 1,
+          difficultyMode: 'Random',
+          score: 0,
+          clientAnswers: [],
+        })
+        .expect(400);
+
+      const body = response.body as ErrorResponse;
+      expect(body.success).toBe(false);
+      expect(body.message).toContain('clientAnswers');
+    });
+
     it('존재하지 않는 카테고리면 404 에러를 응답한다.', async () => {
       const response = await request(app.getHttpServer())
         .post('/api/games/save')

--- a/test/games/save-game-session.e2e-spec.ts
+++ b/test/games/save-game-session.e2e-spec.ts
@@ -1,17 +1,20 @@
-import { Test, TestingModule } from '@nestjs/testing';
+import { execSync } from 'child_process';
 import { INestApplication } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { PrismaClient } from '@prisma/client';
 import * as request from 'supertest';
 import { App } from 'supertest/types';
 import { GenericContainer, StartedTestContainer } from 'testcontainers';
-import { execSync } from 'child_process';
-import { PrismaClient } from '@prisma/client';
-import { AppModule } from '../../src/app.module';
+
 import { ResponseInterceptor } from '@common/interceptors/response.interceptor';
-import { seedCategories } from '../../prisma/seeds/category.seed';
-import { seedSubCategories } from '../../prisma/seeds/subcategory.seed';
-import { seedGitProblems } from '../../prisma/seeds/seed-problems-git';
 import { MAX_PROBLEMS_PER_GAME } from '@games/domain/game.business-rules';
+
+import { seedCategories } from '../../prisma/seeds/category.seed';
+import { seedGitProblems } from '../../prisma/seeds/seed-problems-git';
+import { seedSubCategories } from '../../prisma/seeds/subcategory.seed';
+import { AppModule } from '../../src/app.module';
 
 interface SuccessResponse {
   statusCode: number;
@@ -188,7 +191,9 @@ describe('POST /api/games/save (e2e)', () => {
 
       const body = response.body as ErrorResponse;
       expect(body.success).toBe(false);
-      expect(body.message).toContain('categoryId');
+      expect(body.message).toBe(
+        'categoryId는 1 이상이어야 합니다., categoryId는 정수여야 합니다., categoryId는 필수값입니다., clientAnswers는 정확히 20개여야 합니다.',
+      );
     });
 
     it('difficultyMode를 누락하면 400 에러를 응답한다.', async () => {
@@ -203,7 +208,9 @@ describe('POST /api/games/save (e2e)', () => {
 
       const body = response.body as ErrorResponse;
       expect(body.success).toBe(false);
-      expect(body.message).toContain('difficultyMode');
+      expect(body.message).toBe(
+        'difficultyMode는 Easy, Normal, Hard, Random 중 하나여야 합니다., difficultyMode는 필수값입니다., clientAnswers는 정확히 20개여야 합니다.',
+      );
     });
 
     it('잘못된 difficultyMode를 보내면 400 에러를 응답한다.', async () => {
@@ -219,7 +226,9 @@ describe('POST /api/games/save (e2e)', () => {
 
       const body = response.body as ErrorResponse;
       expect(body.success).toBe(false);
-      expect(body.message).toContain('difficultyMode');
+      expect(body.message).toBe(
+        'difficultyMode는 Easy, Normal, Hard, Random 중 하나여야 합니다., clientAnswers는 정확히 20개여야 합니다.',
+      );
     });
 
     it('score가 음수이면 400 에러를 응답한다.', async () => {
@@ -235,7 +244,9 @@ describe('POST /api/games/save (e2e)', () => {
 
       const body = response.body as ErrorResponse;
       expect(body.success).toBe(false);
-      expect(body.message).toContain('score');
+      expect(body.message).toBe(
+        'score는 0 이상이어야 합니다., clientAnswers는 정확히 20개여야 합니다.',
+      );
     });
 
     it('clientAnswers가 배열이 아니면 400 에러를 응답한다.', async () => {
@@ -251,7 +262,31 @@ describe('POST /api/games/save (e2e)', () => {
 
       const body = response.body as ErrorResponse;
       expect(body.success).toBe(false);
-      expect(body.message).toContain('clientAnswers');
+      expect(body.message).toBe(
+        'clientAnswers는 정확히 20개여야 합니다., clientAnswers는 정확히 20개여야 합니다., clientAnswers는 배열 형식이어야 합니다., each value in nested property clientAnswers must be either object or array',
+      );
+    });
+
+    it(`clientAnswers가 ${MAX_PROBLEMS_PER_GAME}개 미만이면 400 에러를 응답한다.`, async () => {
+      const underSizedAnswers = Array.from({ length: MAX_PROBLEMS_PER_GAME - 1 }, (_, i) => ({
+        problemId: String(i + 1),
+        inputs: [],
+        solved: false,
+      }));
+
+      const response = await request(app.getHttpServer())
+        .post('/api/games/save')
+        .send({
+          categoryId: 1,
+          difficultyMode: 'Easy',
+          score: 0,
+          clientAnswers: underSizedAnswers,
+        })
+        .expect(400);
+
+      const body = response.body as ErrorResponse;
+      expect(body.success).toBe(false);
+      expect(body.message).toBe('clientAnswers는 정확히 20개여야 합니다.');
     });
 
     it(`clientAnswers가 ${MAX_PROBLEMS_PER_GAME}개를 초과하면 400 에러를 응답한다.`, async () => {
@@ -273,7 +308,7 @@ describe('POST /api/games/save (e2e)', () => {
 
       const body = response.body as ErrorResponse;
       expect(body.success).toBe(false);
-      expect(body.message).toContain('clientAnswers');
+      expect(body.message).toBe('clientAnswers는 정확히 20개여야 합니다.');
     });
 
     it('problemId가 숫자 형식이 아니면 400 에러를 응답한다.', async () => {
@@ -333,61 +368,111 @@ describe('POST /api/games/save (e2e)', () => {
 
       const body = response.body as ErrorResponse;
       expect(body.success).toBe(false);
-      expect(body.message).toContain('clientAnswers');
+      expect(body.message).toBe('clientAnswers는 정확히 20개여야 합니다.');
     });
 
     it('존재하지 않는 카테고리면 404 에러를 응답한다.', async () => {
+      const dummyAnswers = Array.from({ length: MAX_PROBLEMS_PER_GAME }, (_, i) => ({
+        problemId: String(i + 1),
+        inputs: [],
+        solved: false,
+      }));
+
       const response = await request(app.getHttpServer())
         .post('/api/games/save')
         .send({
           categoryId: 999,
           difficultyMode: 'Easy',
           score: 0,
-          clientAnswers: [],
+          clientAnswers: dummyAnswers,
         })
         .expect(404);
 
       const body = response.body as ErrorResponse;
       expect(body.success).toBe(false);
-      expect(body.message).toContain('카테고리');
+      expect(body.message).toBe('존재하지 않는 카테고리입니다.');
     });
 
-    it('존재하지 않는 문제 ID가 포함되어 있으면 404 에러를 응답한다.', async () => {
+    it('clientAnswers에 중복된 problemId가 포함되어 있으면 400 에러를 응답한다.', async () => {
+      const answersWithDuplicateProblem = [
+        { problemId: '73', inputs: [], solved: false },
+        { problemId: '73', inputs: [], solved: false },
+        ...Array.from({ length: MAX_PROBLEMS_PER_GAME - 2 }, (_, i) => ({
+          problemId: String(i + 1),
+          inputs: [],
+          solved: false,
+        })),
+      ];
+
       const response = await request(app.getHttpServer())
         .post('/api/games/save')
         .send({
           categoryId: 1,
           difficultyMode: 'Easy',
           score: 0,
-          clientAnswers: [{ problemId: '999999', inputs: [], solved: false }],
+          clientAnswers: answersWithDuplicateProblem,
+        })
+        .expect(400);
+
+      const body = response.body as ErrorResponse;
+      expect(body.success).toBe(false);
+      expect(body.message).toBe('clientAnswers에 중복된 problemId가 포함되어 있습니다.');
+    });
+
+    it('존재하지 않는 문제 ID가 포함되어 있으면 404 에러를 응답한다.', async () => {
+      const answersWithInvalidProblem = [
+        { problemId: '999999', inputs: [], solved: false },
+        ...Array.from({ length: MAX_PROBLEMS_PER_GAME - 1 }, (_, i) => ({
+          problemId: String(i + 1),
+          inputs: [],
+          solved: false,
+        })),
+      ];
+
+      const response = await request(app.getHttpServer())
+        .post('/api/games/save')
+        .send({
+          categoryId: 1,
+          difficultyMode: 'Easy',
+          score: 0,
+          clientAnswers: answersWithInvalidProblem,
         })
         .expect(404);
 
       const body = response.body as ErrorResponse;
       expect(body.success).toBe(false);
-      expect(body.message).toContain('문제 ID');
+      expect(body.message).toBe('존재하지 않는 문제 ID가 포함되어 있습니다. (problemId: 999999)');
     });
 
     it('solved=true인데 정답 처리된 입력이 없으면 400 에러를 응답한다.', async () => {
+      const answersWithIntegrityError = [
+        {
+          problemId: '1',
+          inputs: [{ input: 'wrong', isCorrect: false }],
+          solved: true,
+        },
+        ...Array.from({ length: MAX_PROBLEMS_PER_GAME - 1 }, (_, i) => ({
+          problemId: String(i + 2),
+          inputs: [],
+          solved: true,
+        })),
+      ];
+
       const response = await request(app.getHttpServer())
         .post('/api/games/save')
         .send({
           categoryId: 1,
           difficultyMode: 'Easy',
           score: 10,
-          clientAnswers: [
-            {
-              problemId: '1',
-              inputs: [{ input: 'wrong', isCorrect: false }],
-              solved: true,
-            },
-          ],
+          clientAnswers: answersWithIntegrityError,
         })
         .expect(400);
 
       const body = response.body as ErrorResponse;
       expect(body.success).toBe(false);
-      expect(body.message).toContain('무결성');
+      expect(body.message).toBe(
+        '데이터 무결성 오류: solved가 true이지만 정답 처리된 입력이 없습니다.',
+      );
     });
   });
 });

--- a/test/games/save-game-session.e2e-spec.ts
+++ b/test/games/save-game-session.e2e-spec.ts
@@ -97,6 +97,7 @@ describe('POST /api/games/save (e2e)', () => {
             { problemId: '110', inputs: [], solved: false },
             { problemId: '201', inputs: [], solved: false },
             { problemId: '42', inputs: [], solved: false },
+            { problemId: '43', inputs: [], solved: false },
           ],
         })
         .expect(201);
@@ -163,6 +164,7 @@ describe('POST /api/games/save (e2e)', () => {
             { problemId: '7', inputs: [], solved: false },
             { problemId: '109', inputs: [], solved: false },
             { problemId: '241', inputs: [], solved: false },
+            { problemId: '43', inputs: [], solved: false },
           ],
         })
         .expect(201);

--- a/test/games/save-game-session.e2e-spec.ts
+++ b/test/games/save-game-session.e2e-spec.ts
@@ -1,0 +1,391 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { GenericContainer, StartedTestContainer } from 'testcontainers';
+import { execSync } from 'child_process';
+import { PrismaClient } from '@prisma/client';
+import { AppModule } from '../../src/app.module';
+import { ResponseInterceptor } from '@common/interceptors/response.interceptor';
+import { seedCategories } from '../../prisma/seeds/category.seed';
+import { seedSubCategories } from '../../prisma/seeds/subcategory.seed';
+import { seedGitProblems } from '../../prisma/seeds/seed-problems-git';
+import { MAX_PROBLEMS_PER_GAME } from '@games/domain/game.business-rules';
+
+interface SuccessResponse {
+  statusCode: number;
+  success: boolean;
+  data: {
+    gameSessionId: string;
+  };
+}
+
+interface ErrorResponse {
+  statusCode: number;
+  success: boolean;
+  message: string;
+}
+
+describe('POST /api/games/save (e2e)', () => {
+  let app: INestApplication<App>;
+  let container: StartedTestContainer;
+
+  beforeAll(async () => {
+    container = await new GenericContainer('postgres:16-alpine')
+      .withExposedPorts(5432)
+      .withEnvironment({
+        POSTGRES_USER: 'test',
+        POSTGRES_PASSWORD: 'test',
+        POSTGRES_DB: 'test',
+      })
+      .start();
+
+    const databaseUrl = `postgresql://test:test@${container.getHost()}:${container.getMappedPort(5432)}/test`;
+    process.env.DATABASE_URL = databaseUrl;
+
+    execSync('npx prisma migrate deploy', {
+      env: { ...process.env, DATABASE_URL: databaseUrl },
+    });
+
+    const prisma = new PrismaClient({ datasourceUrl: databaseUrl });
+    await seedCategories(prisma);
+    await seedSubCategories(prisma);
+    await seedGitProblems(prisma);
+    await prisma.$disconnect();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.useGlobalInterceptors(new ResponseInterceptor(app.get(Reflector)));
+    await app.init();
+  }, 60000);
+
+  afterAll(async () => {
+    await app?.close();
+    await container?.stop();
+  });
+
+  describe('✅ 성공 케이스', () => {
+    it('모든 문제를 풀지 못해 0점인 게임 세션을 저장한다.', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/api/games/save')
+        .send({
+          categoryId: 1,
+          difficultyMode: 'Easy',
+          score: 0,
+          clientAnswers: [
+            { problemId: '103', inputs: [], solved: false },
+            { problemId: '136', inputs: [], solved: false },
+            { problemId: '207', inputs: [], solved: false },
+            { problemId: '273', inputs: [], solved: false },
+            { problemId: '143', inputs: [], solved: false },
+            { problemId: '40', inputs: [], solved: false },
+            { problemId: '176', inputs: [], solved: false },
+            { problemId: '109', inputs: [], solved: false },
+            { problemId: '41', inputs: [], solved: false },
+            { problemId: '265', inputs: [], solved: false },
+            { problemId: '275', inputs: [], solved: false },
+            { problemId: '11', inputs: [], solved: false },
+            { problemId: '168', inputs: [], solved: false },
+            { problemId: '9', inputs: [], solved: false },
+            { problemId: '142', inputs: [], solved: false },
+            { problemId: '242', inputs: [], solved: false },
+            { problemId: '110', inputs: [], solved: false },
+            { problemId: '201', inputs: [], solved: false },
+            { problemId: '42', inputs: [], solved: false },
+          ],
+        })
+        .expect(201);
+
+      const body = response.body as SuccessResponse;
+      expect(body.success).toBe(true);
+      expect(body.data.gameSessionId).toBeDefined();
+    });
+
+    it('일부 문제를 맞춘 게임 세션을 저장한다.', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/api/games/save')
+        .send({
+          categoryId: 1,
+          difficultyMode: 'Easy',
+          score: 30,
+          clientAnswers: [
+            {
+              problemId: '73',
+              inputs: [
+                { input: 'git branch', isCorrect: false },
+                { input: 'git remote', isCorrect: true },
+              ],
+              solved: true,
+            },
+            {
+              problemId: '103',
+              inputs: [
+                { input: 'git revert', isCorrect: false },
+                { input: 'git rolback', isCorrect: false },
+              ],
+              solved: false,
+            },
+            {
+              problemId: '265',
+              inputs: [{ input: 'git tag', isCorrect: true }],
+              solved: true,
+            },
+            {
+              problemId: '134',
+              inputs: [{ input: 'git config --email "john@example.com"', isCorrect: false }],
+              solved: false,
+            },
+            { problemId: '40', inputs: [], solved: false },
+            {
+              problemId: '34',
+              inputs: [{ input: 'git branch', isCorrect: true }],
+              solved: true,
+            },
+            { problemId: '4', inputs: [], solved: false },
+            { problemId: '174', inputs: [], solved: false },
+            { problemId: '306', inputs: [], solved: false },
+            { problemId: '200', inputs: [], solved: false },
+            {
+              problemId: '237',
+              inputs: [{ input: 'git stasy', isCorrect: false }],
+              solved: false,
+            },
+            { problemId: '69', inputs: [], solved: false },
+            { problemId: '11', inputs: [], solved: false },
+            { problemId: '10', inputs: [], solved: false },
+            { problemId: '6', inputs: [], solved: false },
+            { problemId: '307', inputs: [], solved: false },
+            { problemId: '7', inputs: [], solved: false },
+            { problemId: '109', inputs: [], solved: false },
+            { problemId: '241', inputs: [], solved: false },
+          ],
+        })
+        .expect(201);
+
+      const body = response.body as SuccessResponse;
+      expect(body.success).toBe(true);
+      expect(body.data.gameSessionId).toBeDefined();
+    });
+
+    it('clientAnswers가 빈 배열이어도 게임 세션을 저장한다.', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/api/games/save')
+        .send({
+          categoryId: 1,
+          difficultyMode: 'Random',
+          score: 0,
+          clientAnswers: [],
+        })
+        .expect(201);
+
+      const body = response.body as SuccessResponse;
+      expect(body.success).toBe(true);
+      expect(body.data.gameSessionId).toBeDefined();
+    });
+  });
+
+  describe('❌ 실패 케이스 - RequestBody 유효성 검증', () => {
+    it('categoryId를 누락하면 400 에러를 응답한다.', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/api/games/save')
+        .send({
+          difficultyMode: 'Easy',
+          score: 0,
+          clientAnswers: [],
+        })
+        .expect(400);
+
+      const body = response.body as ErrorResponse;
+      expect(body.success).toBe(false);
+      expect(body.message).toContain('categoryId');
+    });
+
+    it('difficultyMode를 누락하면 400 에러를 응답한다.', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/api/games/save')
+        .send({
+          categoryId: 1,
+          score: 0,
+          clientAnswers: [],
+        })
+        .expect(400);
+
+      const body = response.body as ErrorResponse;
+      expect(body.success).toBe(false);
+      expect(body.message).toContain('difficultyMode');
+    });
+
+    it('잘못된 difficultyMode를 보내면 400 에러를 응답한다.', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/api/games/save')
+        .send({
+          categoryId: 1,
+          difficultyMode: 'InvalidMode',
+          score: 0,
+          clientAnswers: [],
+        })
+        .expect(400);
+
+      const body = response.body as ErrorResponse;
+      expect(body.success).toBe(false);
+      expect(body.message).toContain('difficultyMode');
+    });
+
+    it('score가 음수이면 400 에러를 응답한다.', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/api/games/save')
+        .send({
+          categoryId: 1,
+          difficultyMode: 'Easy',
+          score: -1,
+          clientAnswers: [],
+        })
+        .expect(400);
+
+      const body = response.body as ErrorResponse;
+      expect(body.success).toBe(false);
+      expect(body.message).toContain('score');
+    });
+
+    it('clientAnswers가 배열이 아니면 400 에러를 응답한다.', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/api/games/save')
+        .send({
+          categoryId: 1,
+          difficultyMode: 'Easy',
+          score: 0,
+          clientAnswers: 'not-an-array',
+        })
+        .expect(400);
+
+      const body = response.body as ErrorResponse;
+      expect(body.success).toBe(false);
+      expect(body.message).toContain('clientAnswers');
+    });
+
+    it(`clientAnswers가 ${MAX_PROBLEMS_PER_GAME}개를 초과하면 400 에러를 응답한다.`, async () => {
+      const oversizedAnswers = Array.from({ length: MAX_PROBLEMS_PER_GAME + 1 }, (_, i) => ({
+        problemId: String(i + 1),
+        inputs: [],
+        solved: false,
+      }));
+
+      const response = await request(app.getHttpServer())
+        .post('/api/games/save')
+        .send({
+          categoryId: 1,
+          difficultyMode: 'Easy',
+          score: 0,
+          clientAnswers: oversizedAnswers,
+        })
+        .expect(400);
+
+      const body = response.body as ErrorResponse;
+      expect(body.success).toBe(false);
+      expect(body.message).toContain('clientAnswers');
+    });
+
+    it('problemId가 숫자 형식이 아니면 400 에러를 응답한다.', async () => {
+      await request(app.getHttpServer())
+        .post('/api/games/save')
+        .send({
+          categoryId: 1,
+          difficultyMode: 'Easy',
+          score: 0,
+          clientAnswers: [{ problemId: 'abc', inputs: [], solved: false }],
+        })
+        .expect(400);
+    });
+
+    it('solved가 boolean이 아니면 400 에러를 응답한다.', async () => {
+      await request(app.getHttpServer())
+        .post('/api/games/save')
+        .send({
+          categoryId: 1,
+          difficultyMode: 'Easy',
+          score: 0,
+          clientAnswers: [{ problemId: '1', inputs: [], solved: 'yes' }],
+        })
+        .expect(400);
+    });
+
+    it('input이 빈 문자열이면 400 에러를 응답한다.', async () => {
+      await request(app.getHttpServer())
+        .post('/api/games/save')
+        .send({
+          categoryId: 1,
+          difficultyMode: 'Easy',
+          score: 0,
+          clientAnswers: [
+            {
+              problemId: '1',
+              inputs: [{ input: '', isCorrect: false }],
+              solved: false,
+            },
+          ],
+        })
+        .expect(400);
+    });
+  });
+
+  describe('❌ 실패 케이스 - 비즈니스 로직 검증', () => {
+    it('존재하지 않는 카테고리면 404 에러를 응답한다.', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/api/games/save')
+        .send({
+          categoryId: 999,
+          difficultyMode: 'Easy',
+          score: 0,
+          clientAnswers: [],
+        })
+        .expect(404);
+
+      const body = response.body as ErrorResponse;
+      expect(body.success).toBe(false);
+      expect(body.message).toContain('카테고리');
+    });
+
+    it('존재하지 않는 문제 ID가 포함되어 있으면 404 에러를 응답한다.', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/api/games/save')
+        .send({
+          categoryId: 1,
+          difficultyMode: 'Easy',
+          score: 0,
+          clientAnswers: [{ problemId: '999999', inputs: [], solved: false }],
+        })
+        .expect(404);
+
+      const body = response.body as ErrorResponse;
+      expect(body.success).toBe(false);
+      expect(body.message).toContain('문제 ID');
+    });
+
+    it('solved=true인데 정답 처리된 입력이 없으면 400 에러를 응답한다.', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/api/games/save')
+        .send({
+          categoryId: 1,
+          difficultyMode: 'Easy',
+          score: 10,
+          clientAnswers: [
+            {
+              problemId: '1',
+              inputs: [{ input: 'wrong', isCorrect: false }],
+              solved: true,
+            },
+          ],
+        })
+        .expect(400);
+
+      const body = response.body as ErrorResponse;
+      expect(body.success).toBe(false);
+      expect(body.message).toContain('무결성');
+    });
+  });
+});


### PR DESCRIPTION
# 백엔드 PR

## 📋 변경 사항 요약

게임종료후 - 클라이언트의 게임 세션 저장 API 추가

API 데코레이터부분 리팩터링은 #26 에서 작업하겠습니다.

## 🔗 관련 Issue

Closes #16 

## 🎯 변경 내용

- [x] **ProblemRawRow의 difficulty 타입 수정**
  - [AS-IS] **ProblemDifficulty**(`Easy`|`Normal`|`Hard`)
  - [TO-BE] **Difficulty**(Prisma.Enum `EASY`|`NORMAL`|`HARD`)
  - 이유
    - Raw쿼리에서 problem테이블에서 조회된 difficulty(문제난이도)는 Enum으로 표기하기때문입니다.
    - ProblemRawRow는 infrastructure 단에서 실제 raw쿼리의 결과를 저장하기때문에 `@prisma/client`값도 데이터베이스와 관련된 값으로 infrastructure에 해당되기때문입니다.

<br>

- [x] **게임 저장 API** 
  - (controller) **saveGameSession**
  - (service) **createGameSession**
    - service함수에 인자파라미터가 3개이상이므로, application/service-dto/create-game-session.service-dto.ts 에서 `CreateGameSessionServiceRequestDto`를 만들었습니다. 
    - Command가 아닌 ServiceRequestDto 라고 한 이유는 계층마다 dto가 추가될때마다 이름이 달리하게되면 혼란이 올 수 있어서 서비스계층의 dto는 ServiceDto로 정의했습니다.
  - (repository) saveGameSession

<br>

- [x] **클라이언트 데이터 검증로직을 추가했습니다.**
  - 클라이언트의 데이터를 서버에서 그대로 믿고 데이터베이스에 저장하는것은 위험합니다. 
  그 이유는 실제로 0점인데 점수를 999점으로 조작해서 데이터베이스에 저장되는 악의적인 사례케이스를 대비하기 위함입니다. 
  - 따라서 사용자가 실제로 문제를 풀었는지 검증하고 문제정보를 가져와서 배점대로 계산합니다. 
    **서버가 신뢰할 수 있는 데이터는 서버가 직접 계산한 데이터**라고 생각합니다.
  - GameService의 프라이빗함수 `validateAndCalculateScore`, `validateCategory`, `validateGameProblems`, `calculateScore`가 해당됩니다.

- [x] API Swagger
> Requests

<img width="1269" height="525" alt="image" src="https://github.com/user-attachments/assets/d0e3207b-381c-4edf-aa30-1ef891fe02ee" />


<br>

> Responses
<img width="1268" height="746" alt="image" src="https://github.com/user-attachments/assets/de08542a-90a2-47af-8431-d991ccd9c1f2" />


## 📌 추가 참고사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * POST /games/save endpoint with server-side validation, authoritative scoring and persistent session logging; new request/response DTOs and client-answer shapes.

* **Documentation**
  * Expanded API docs with examples and detailed 400/404 error descriptions.

* **Bug Fixes**
  * Prevents client score tampering; clearer errors for missing/invalid category or problems and integrity violations.

* **Tests**
  * Extensive unit and end-to-end coverage for success, validation, and business-rule failures (including DB-backed e2e). 

* **Chores**
  * Code style/import ordering configured via Prettier plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->