### PR TITLE
자주 틀린 명령어 응답에 category 정보 추가

### DIFF
--- a/src/games/application/games.service.spec.ts
+++ b/src/games/application/games.service.spec.ts
@@ -58,11 +58,11 @@ describe('GamesService', () => {
 
     beforeEach(() => {
       mockCommands = [
-        FrequentWrongCommand.from({ subCategory: 'Branch', wrongCount: 12 }),
-        FrequentWrongCommand.from({ subCategory: 'Commit', wrongCount: 9 }),
-        FrequentWrongCommand.from({ subCategory: 'Merge', wrongCount: 7 }),
-        FrequentWrongCommand.from({ subCategory: 'Remote', wrongCount: 5 }),
-        FrequentWrongCommand.from({ subCategory: 'Rebase', wrongCount: 3 }),
+        FrequentWrongCommand.from({ category: 'Git', subCategory: 'Branch', wrongCount: 12 }),
+        FrequentWrongCommand.from({ category: 'Git', subCategory: 'Commit', wrongCount: 9 }),
+        FrequentWrongCommand.from({ category: 'Git', subCategory: 'Merge', wrongCount: 7 }),
+        FrequentWrongCommand.from({ category: 'Git', subCategory: 'Remote', wrongCount: 5 }),
+        FrequentWrongCommand.from({ category: 'Git', subCategory: 'Rebase', wrongCount: 3 }),
       ];
 
       mockCategories = [
@@ -109,14 +109,17 @@ describe('GamesService', () => {
       const result = await service.getUserMistakeAnalysis(userId);
 
       expect(result.frequentWrongCommands[0]).toMatchObject({
+        category: 'Git',
         subCategory: 'Branch',
         wrongCount: 12,
       });
       expect(result.frequentWrongCommands[1]).toMatchObject({
+        category: 'Git',
         subCategory: 'Commit',
         wrongCount: 9,
       });
       expect(result.frequentWrongCommands[4]).toMatchObject({
+        category: 'Git',
         subCategory: 'Rebase',
         wrongCount: 3,
       });

--- a/src/games/domain/user-mistake-analysis.entity.ts
+++ b/src/games/domain/user-mistake-analysis.entity.ts
@@ -1,13 +1,14 @@
 export class FrequentWrongCommand {
   private constructor(
+    readonly category: string,
     readonly subCategory: string,
     readonly wrongCount: number,
   ) {}
 
   static from(
-    data: Pick<FrequentWrongCommand, 'subCategory' | 'wrongCount'>,
+    data: Pick<FrequentWrongCommand, 'category' | 'subCategory' | 'wrongCount'>,
   ): FrequentWrongCommand {
-    return new FrequentWrongCommand(data.subCategory, data.wrongCount);
+    return new FrequentWrongCommand(data.category, data.subCategory, data.wrongCount);
   }
 }
 

--- a/src/games/infrastructure/games.repository.ts
+++ b/src/games/infrastructure/games.repository.ts
@@ -120,22 +120,27 @@ export class GameRepositoryImpl implements IGameRepository {
    * - 오답 횟수가 많은 순으로 정렬 후 상위 5개만 반환
    */
   async getFrequentWrongCommands(userId: bigint): Promise<FrequentWrongCommand[]> {
-    const result = await this.prisma.$queryRaw<Array<{ subCategory: string; wrongCount: bigint }>>`
+    const result = await this.prisma.$queryRaw<
+      Array<{ category: string; subCategory: string; wrongCount: bigint }>
+    >`
       SELECT
+        c.name as category,
         sc.name as "subCategory",
         COUNT(*) as "wrongCount"
       FROM game_session_logs gsl
       JOIN game_sessions gs ON gsl.session_id = gs.id
       JOIN problems p ON gsl.problem_id = p.id
+      JOIN categories c ON p.category_id = c.id
       JOIN sub_categories sc ON p.sub_category_id = sc.id
       WHERE gsl.is_solved = false AND gs.user_id = ${userId}
-      GROUP BY sc.id, sc.name
+      GROUP BY c.id, c.name, sc.id, sc.name
       ORDER BY "wrongCount" DESC
       LIMIT 5
     `;
 
     return result.map((row) =>
       FrequentWrongCommand.from({
+        category: row.category,
         subCategory: row.subCategory,
         wrongCount: Number(row.wrongCount),
       }),

--- a/src/games/infrastructure/games.repository.ts
+++ b/src/games/infrastructure/games.repository.ts
@@ -156,7 +156,7 @@ export class GameRepositoryImpl implements IGameRepository {
       Array<{ category: string; wrongRatio: number; wrongCount: bigint; iconUrl: string | null }>
     >`
       SELECT
-        c.name as category,
+        c.name as "category",
         c.icon_url as "iconUrl",
         COUNT(CASE WHEN gsl.is_solved = false THEN 1 END) as "wrongCount",
         ROUND(

--- a/src/games/infrastructure/games.repository.ts
+++ b/src/games/infrastructure/games.repository.ts
@@ -124,7 +124,7 @@ export class GameRepositoryImpl implements IGameRepository {
       Array<{ category: string; subCategory: string; wrongCount: bigint }>
     >`
       SELECT
-        c.name as category,
+        c.name as "category",
         sc.name as "subCategory",
         COUNT(*) as "wrongCount"
       FROM game_session_logs gsl

--- a/src/users/application/users.service.spec.ts
+++ b/src/users/application/users.service.spec.ts
@@ -141,8 +141,8 @@ describe('UsersService', () => {
 
     beforeEach(() => {
       const mockCommands = [
-        FrequentWrongCommand.from({ subCategory: 'Branch', wrongCount: 12 }),
-        FrequentWrongCommand.from({ subCategory: 'Commit', wrongCount: 9 }),
+        FrequentWrongCommand.from({ category: 'Git', subCategory: 'Branch', wrongCount: 12 }),
+        FrequentWrongCommand.from({ category: 'Git', subCategory: 'Commit', wrongCount: 9 }),
       ];
 
       const mockCategories = [

--- a/src/users/presentation/dto/get-user-analysis.dto.ts
+++ b/src/users/presentation/dto/get-user-analysis.dto.ts
@@ -23,6 +23,12 @@ export class GetUserAnalysisParamDto {
 
 export class FrequentWrongCommandDto {
   @ApiProperty({
+    description: '카테고리 이름',
+    example: 'Git',
+  })
+  category: string;
+
+  @ApiProperty({
     description: '서브 카테고리 이름',
     example: 'Branch',
   })

--- a/src/users/presentation/users.controller.spec.ts
+++ b/src/users/presentation/users.controller.spec.ts
@@ -132,9 +132,9 @@ describe('UsersController', () => {
 
     beforeEach(() => {
       const mockCommands = [
-        FrequentWrongCommand.from({ subCategory: 'Branch', wrongCount: 12 }),
-        FrequentWrongCommand.from({ subCategory: 'Commit', wrongCount: 9 }),
-        FrequentWrongCommand.from({ subCategory: 'Merge', wrongCount: 7 }),
+        FrequentWrongCommand.from({ category: 'Git', subCategory: 'Branch', wrongCount: 12 }),
+        FrequentWrongCommand.from({ category: 'Git', subCategory: 'Commit', wrongCount: 9 }),
+        FrequentWrongCommand.from({ category: 'Git', subCategory: 'Merge', wrongCount: 7 }),
       ];
 
       const mockCategories = [
@@ -171,6 +171,7 @@ describe('UsersController', () => {
 
       expect(result.frequentWrongCommands).toHaveLength(3);
       expect(result.frequentWrongCommands[0]).toMatchObject({
+        category: 'Git',
         subCategory: 'Branch',
         wrongCount: 12,
       });


### PR DESCRIPTION
# 백엔드 PR

## 📋 변경 사항 요약
유저 분석 API 응답 중 자주 틀린 명렁어에 상위 카테고리 이름을 포함하도록 수정했습니다.
- [관련 Slack 스레드](https://dnd-ayn8252.slack.com/archives/C0A5WSAKQ0J/p1771062074414799)
<!-- PR의 목적을 간략히 설명 -->


## 🔗 관련 Issue

Closes #29 

## 🎯 변경 내용

- [ ] 응답 dto, entity 필드 수정
- [ ] 쿼리 시 카테고리 이름 가져오도록 변경
- [ ] 테스트 코드 수정

## 📌 추가 참고사항
<img width="557" height="654" alt="image" src="https://github.com/user-attachments/assets/716703df-3f46-4db9-a8f3-f6e8d51a4fa6" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mistake analysis now includes a category field (e.g., "Git") for frequent wrong commands, making reports and user analysis clearer and easier to filter or group by category.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->