### PR TITLE
[게임] game api swagger 리팩터링 & 게임옵션 api 컬럼 추가 (#26, #31)

### DIFF
--- a/src/games/presentation/decorators/game-stream-swagger.decorator.ts
+++ b/src/games/presentation/decorators/game-stream-swagger.decorator.ts
@@ -1,6 +1,13 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiQuery } from '@nestjs/swagger';
+
+import {
+  createSwaggerBadRequest,
+  createSwaggerNotFound,
+  createSwaggerServerErrors,
+} from '@common/utils/swagger-error-response.util';
+
 import { GameDifficultyMode } from '../../domain/game.business-rules';
-import { applyDecorators, HttpStatus } from '@nestjs/common';
-import { ApiOperation, ApiQuery, ApiResponse } from '@nestjs/swagger';
 
 export function ApiGameStream() {
   return applyDecorators(
@@ -17,14 +24,13 @@ export function ApiGameStream() {
       enum: GameDifficultyMode,
       description: '난이도 모드',
     }),
-    ApiResponse({
-      status: HttpStatus.OK,
+    ApiOkResponse({
       description: 'SSE 이벤트 스트림 (text/event-stream)',
       content: {
         'text/event-stream': {
           examples: {
             'timer 이벤트': {
-              summary: '매 1초마다 남은 시간 전송',
+              summary: 'timer 이벤트: 매 1초마다 남은 시간 전송',
               description: '이벤트명: `timer`',
               value: {
                 statusCode: 200,
@@ -35,7 +41,7 @@ export function ApiGameStream() {
               },
             },
             'problem 이벤트': {
-              summary: '랜덤 간격으로 문제 전송',
+              summary: 'problem 이벤트: 랜덤 간격으로 문제 전송',
               description: '이벤트명: `problem`',
               value: {
                 statusCode: 200,
@@ -52,7 +58,7 @@ export function ApiGameStream() {
               },
             },
             'end 이벤트': {
-              summary: '게임 종료 시 전송',
+              summary: 'end 이벤트: 게임 종료 시 전송',
               description: '이벤트명: `end`',
               value: {
                 statusCode: 200,
@@ -66,61 +72,17 @@ export function ApiGameStream() {
         },
       },
     }),
-    ApiResponse({
-      status: HttpStatus.BAD_REQUEST,
-      description: '잘못된 요청 파라미터',
-      content: {
-        'application/json': {
-          examples: {
-            'categoryId 필수 누락': {
-              value: {
-                statusCode: 400,
-                success: false,
-                message: 'categoryId 는 필수값입니다.',
-              },
-            },
-            'difficultyMode 필수 누락': {
-              value: {
-                statusCode: 400,
-                success: false,
-                message: 'difficultyMode 는 필수값입니다.',
-              },
-            },
-            'difficultyMode 형식 오류': {
-              value: {
-                statusCode: 400,
-                success: false,
-                message: 'difficultyMode는 Easy, Normal, Hard, Random 중 하나여야 합니다.',
-              },
-            },
-          },
-        },
+    createSwaggerBadRequest([
+      { description: 'categoryId 필수 누락', message: 'categoryId 는 필수값입니다.' },
+      { description: 'difficultyMode 필수 누락', message: 'difficultyMode 는 필수값입니다.' },
+      {
+        description: 'difficultyMode 형식 오류',
+        message: 'difficultyMode는 Easy, Normal, Hard, Random 중 하나여야 합니다.',
       },
-    }),
-    ApiResponse({
-      status: HttpStatus.NOT_FOUND,
-      description: '리소스 찾을 수 없음',
-      content: {
-        'application/json': {
-          examples: {
-            '존재하지 않는 카테고리': {
-              value: {
-                statusCode: 404,
-                success: false,
-                message: '존재하지 않은 카테고리 입니다.',
-              },
-            },
-          },
-        },
-      },
-    }),
-    ApiResponse({
-      status: 500,
-      description: 'Internal Server Error',
-    }),
-    ApiResponse({
-      status: 503,
-      description: 'Service Unavailable',
-    }),
+    ]),
+    createSwaggerNotFound([
+      { description: '존재하지 않는 카테고리', message: '존재하지 않은 카테고리 입니다.' },
+    ]),
+    ...createSwaggerServerErrors(),
   );
 }

--- a/src/games/presentation/decorators/get-game-options-swagger.decorator.ts
+++ b/src/games/presentation/decorators/get-game-options-swagger.decorator.ts
@@ -1,36 +1,44 @@
 import { applyDecorators } from '@nestjs/common';
-import {
-  ApiExtraModels,
-  ApiOkResponse,
-  ApiOperation,
-  ApiResponse,
-  getSchemaPath,
-} from '@nestjs/swagger';
+import { ApiExtraModels, ApiOkResponse, ApiOperation, getSchemaPath } from '@nestjs/swagger';
 
+import { createSwaggerServerErrors } from '@/common/utils/swagger-error-response.util';
 import { ApiResponseDto } from '@common/dto/api-response.dto';
-import { GetGameOptionsResponseDto } from '../dto/get-game-options.dto';
+
+import { CategoryDto, GetGameOptionsResponseDto } from '../dto/get-game-options.dto';
 
 export function ApiGetGameOptions() {
   return applyDecorators(
     ApiOperation({ summary: '게임 옵션 조회 (카테고리, 난이도)' }),
-    ApiExtraModels(ApiResponseDto, GetGameOptionsResponseDto),
+    ApiExtraModels(ApiResponseDto, GetGameOptionsResponseDto, CategoryDto),
     ApiOkResponse({
       description: '게임 옵션 조회 성공',
-      schema: {
-        type: 'object',
-        $ref: getSchemaPath(ApiResponseDto),
-        properties: {
-          data: { $ref: getSchemaPath(GetGameOptionsResponseDto) },
+      content: {
+        'application/json': {
+          schema: {
+            allOf: [
+              { $ref: getSchemaPath(ApiResponseDto) },
+              {
+                properties: {
+                  data: { $ref: getSchemaPath(GetGameOptionsResponseDto) },
+                },
+              },
+            ],
+          },
+          example: {
+            statusCode: 200,
+            success: true,
+            data: {
+              categories: [
+                { id: 1, name: 'Git', iconUrl: 'https://cdn.orvit.net/categories/git.png' },
+                { id: 2, name: 'Linux', iconUrl: 'https://cdn.orvit.net/categories/linux.png' },
+                { id: 3, name: 'Docker', iconUrl: 'https://cdn.orvit.net/categories/docker.png' },
+              ],
+              difficultyModes: ['Easy', 'Normal', 'Hard', 'Random'],
+            },
+          },
         },
       },
     }),
-    ApiResponse({
-      status: 500,
-      description: 'Internal Server Error',
-    }),
-    ApiResponse({
-      status: 503,
-      description: 'Service Unavailable',
-    }),
+    ...createSwaggerServerErrors(),
   );
 }

--- a/src/games/presentation/decorators/get-game-options-swagger.decorator.ts
+++ b/src/games/presentation/decorators/get-game-options-swagger.decorator.ts
@@ -1,8 +1,8 @@
 import { applyDecorators } from '@nestjs/common';
 import { ApiExtraModels, ApiOkResponse, ApiOperation, getSchemaPath } from '@nestjs/swagger';
 
-import { createSwaggerServerErrors } from '@/common/utils/swagger-error-response.util';
 import { ApiResponseDto } from '@common/dto/api-response.dto';
+import { createSwaggerServerErrors } from '@common/utils/swagger-error-response.util';
 
 import { CategoryDto, GetGameOptionsResponseDto } from '../dto/get-game-options.dto';
 
@@ -23,18 +23,6 @@ export function ApiGetGameOptions() {
                 },
               },
             ],
-          },
-          example: {
-            statusCode: 200,
-            success: true,
-            data: {
-              categories: [
-                { id: 1, name: 'Git', iconUrl: 'https://cdn.orvit.net/categories/git.png' },
-                { id: 2, name: 'Linux', iconUrl: 'https://cdn.orvit.net/categories/linux.png' },
-                { id: 3, name: 'Docker', iconUrl: 'https://cdn.orvit.net/categories/docker.png' },
-              ],
-              difficultyModes: ['Easy', 'Normal', 'Hard', 'Random'],
-            },
           },
         },
       },

--- a/src/games/presentation/dto/get-game-options.dto.ts
+++ b/src/games/presentation/dto/get-game-options.dto.ts
@@ -1,7 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { plainToInstance } from 'class-transformer';
+
 import { GameOptions } from '../../domain/game-options.entity';
 import { GameDifficultyMode } from '../../domain/game.business-rules';
-import { ApiProperty } from '@nestjs/swagger';
-import { plainToInstance } from 'class-transformer';
 
 export class CategoryDto {
   @ApiProperty({
@@ -15,6 +17,12 @@ export class CategoryDto {
     example: 'Git',
   })
   name: string;
+
+  @ApiProperty({
+    description: '카테고리 icon Url',
+    example: 'https://cdn.orvit.net/categories/git.png',
+  })
+  iconUrl: string;
 }
 
 export class GetGameOptionsResponseDto {
@@ -22,9 +30,9 @@ export class GetGameOptionsResponseDto {
     description: '게임 카테고리 목록',
     type: [CategoryDto],
     example: [
-      { id: 1, name: 'Git' },
-      { id: 2, name: 'Linux' },
-      { id: 3, name: 'Docker' },
+      { id: 1, name: 'Git', iconUrl: 'https://cdn.orvit.net/categories/git.png' },
+      { id: 2, name: 'Linux', iconUrl: 'https://cdn.orvit.net/categories/linux.png' },
+      { id: 3, name: 'Docker', iconUrl: 'https://cdn.orvit.net/categories/docker.png' },
     ],
   })
   categories: CategoryDto[];

--- a/src/games/presentation/dto/save-game-session.dto.ts
+++ b/src/games/presentation/dto/save-game-session.dto.ts
@@ -119,6 +119,7 @@ export class SaveGameSessionRequestDto {
 export class SaveGameSessionResponseDto {
   @ApiProperty({
     description: '생성된 게임세션 ID',
+    example: '7',
   })
   gameSessionId: string;
 

--- a/test/games/get-game-options.e2e-spec.ts
+++ b/test/games/get-game-options.e2e-spec.ts
@@ -18,7 +18,7 @@ interface GameOptionsApiResponse {
   statusCode: number;
   success: boolean;
   data: {
-    categories: { id: number; name: string }[];
+    categories: { id: number; name: string; iconUrl: string }[];
     difficultyModes: GameDifficultyMode[];
   };
 }

--- a/test/games/get-game-options.e2e-spec.ts
+++ b/test/games/get-game-options.e2e-spec.ts
@@ -1,15 +1,18 @@
-import { Test, TestingModule } from '@nestjs/testing';
+import { execSync } from 'child_process';
 import { INestApplication } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { PrismaClient } from '@prisma/client';
 import * as request from 'supertest';
 import { App } from 'supertest/types';
 import { GenericContainer, StartedTestContainer } from 'testcontainers';
-import { execSync } from 'child_process';
-import { PrismaClient } from '@prisma/client';
-import { AppModule } from '../../src/app.module';
+
 import { ResponseInterceptor } from '@common/interceptors/response.interceptor';
 import { DIFFICULTY_MODES, GameDifficultyMode } from '@games/domain/game.business-rules';
+
 import { seedCategories } from '../../prisma/seeds/category.seed';
+import { AppModule } from '../../src/app.module';
 
 interface GameOptionsApiResponse {
   statusCode: number;
@@ -68,9 +71,21 @@ describe('GET /api/games/options (e2e)', () => {
     expect(body.success).toBe(true);
     expect(body.data.categories).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ id: 1, name: 'Git' }),
-        expect.objectContaining({ id: 2, name: 'Linux' }),
-        expect.objectContaining({ id: 3, name: 'Docker' }),
+        expect.objectContaining({
+          id: 1,
+          name: 'Git',
+          iconUrl: 'https://cdn.orvit.net/categories/git.png',
+        }),
+        expect.objectContaining({
+          id: 2,
+          name: 'Linux',
+          iconUrl: 'https://cdn.orvit.net/categories/linux.png',
+        }),
+        expect.objectContaining({
+          id: 3,
+          name: 'Docker',
+          iconUrl: 'https://cdn.orvit.net/categories/docker.png',
+        }),
       ]),
     );
     expect(body.data.difficultyModes).toEqual(DIFFICULTY_MODES);


### PR DESCRIPTION
# 백엔드 PR

## 📋 변경 사항 요약

<!-- PR의 목적을 간략히 설명 -->

## 🔗 관련 Issue

Closes #26
Closes #31

## 🎯 변경 내용

- [x] 게임옵션 API 응답데이터에 iconUrl 추가 (관련 e2e테스트케이스에도 반영)
- [x] 게임 옵션 API - swagger 리팩터링
- [x] 게임 저장 API - swagger 리팩터링 (#27 에서 이미 완료)
  - 응답데이터 gameSessionId 수정
- [x] 게임 스트림 API - swagger리팩터링

## 📌 추가 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Category items now include icon URLs for visual display in the interface.

* **Documentation**
  * API documentation responses standardized and simplified with clearer success/error descriptors.
  * Operation example summaries updated to include event name prefixes.
  * Response example updated to include a sample gameSessionId.

* **Tests**
  * E2E assertions updated to expect category icon URLs in API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->