### PR TITLE
[유저] 내 정보 조회 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,3 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 # claude
 .claude/setting.local.json
-.claude/*
-CLAUDE.md
-AGENTS.md

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 # claude
 .claude/setting.local.json
+.claude/*
+CLAUDE.md
+AGENTS.md

--- a/src/users/application/users.service.ts
+++ b/src/users/application/users.service.ts
@@ -1,12 +1,12 @@
 import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 
-import { IUsersRepository, USER_REPOSITORY } from '../domain/users.repository.interface';
-import { User } from '../domain/users.entity';
+import { GamesService } from '@games/application/games.service';
+import { UserMistakeAnalysis } from '@games/domain/user-mistake-analysis.entity';
+
 import { UserStats } from '../domain/user-stats.entity';
 import { UserStatsMapper } from '../domain/user-stats.mapper';
-
-import { UserMistakeAnalysis } from '@games/domain/user-mistake-analysis.entity';
-import { GamesService } from '@games/application/games.service';
+import { User } from '../domain/users.entity';
+import { IUsersRepository, USER_REPOSITORY } from '../domain/users.repository.interface';
 
 @Injectable()
 export class UsersService {
@@ -14,6 +14,18 @@ export class UsersService {
     @Inject(USER_REPOSITORY) private readonly usersRepository: IUsersRepository,
     private readonly gamesService: GamesService,
   ) {}
+
+  /**
+   * @description id로 유저 정보 조회
+   */
+  async findById(userId: bigint): Promise<User> {
+    const user = await this.usersRepository.findByIdWithTier(userId);
+    if (!user) {
+      throw new NotFoundException('존재하지 않는 사용자입니다.');
+    }
+
+    return User.from(user);
+  }
 
   async getRanksByPageAndSize(
     page: number,

--- a/src/users/presentation/decorators/get-my-info.swagger.decorator.ts
+++ b/src/users/presentation/decorators/get-my-info.swagger.decorator.ts
@@ -7,11 +7,11 @@ import {
   getSchemaPath,
 } from '@nestjs/swagger';
 
+import { ApiResponseDto } from '@common/dto/api-response.dto';
 import {
   createSwaggerAuthErrors,
   createSwaggerServerErrors,
-} from '@/common/utils/swagger-error-response.util';
-import { ApiResponseDto } from '@common/dto/api-response.dto';
+} from '@common/utils/swagger-error-response.util';
 
 import { GetMyInfoResponseDto } from '../dto/get-my-info.dto';
 

--- a/src/users/presentation/decorators/get-my-info.swagger.decorator.ts
+++ b/src/users/presentation/decorators/get-my-info.swagger.decorator.ts
@@ -7,7 +7,10 @@ import {
   getSchemaPath,
 } from '@nestjs/swagger';
 
-import { createSwaggerAuthErrors } from '@/common/utils/swagger-error-response.util';
+import {
+  createSwaggerAuthErrors,
+  createSwaggerServerErrors,
+} from '@/common/utils/swagger-error-response.util';
 import { ApiResponseDto } from '@common/dto/api-response.dto';
 
 import { GetMyInfoResponseDto } from '../dto/get-my-info.dto';
@@ -28,5 +31,6 @@ export function ApiGetMyInfo() {
       },
     }),
     ...createSwaggerAuthErrors(),
+    ...createSwaggerServerErrors(),
   );
 }

--- a/src/users/presentation/decorators/get-my-info.swagger.decorator.ts
+++ b/src/users/presentation/decorators/get-my-info.swagger.decorator.ts
@@ -1,0 +1,32 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiExtraModels,
+  ApiOkResponse,
+  ApiOperation,
+  getSchemaPath,
+} from '@nestjs/swagger';
+
+import { createSwaggerAuthErrors } from '@/common/utils/swagger-error-response.util';
+import { ApiResponseDto } from '@common/dto/api-response.dto';
+
+import { GetMyInfoResponseDto } from '../dto/get-my-info.dto';
+
+export function ApiGetMyInfo() {
+  return applyDecorators(
+    ApiBearerAuth(),
+    ApiOperation({ summary: '내 정보 조회' }),
+    ApiExtraModels(ApiResponseDto, GetMyInfoResponseDto),
+    ApiOkResponse({
+      description: '내 정보 조회 성공',
+      schema: {
+        type: 'object',
+        $ref: getSchemaPath(ApiResponseDto),
+        properties: {
+          data: { $ref: getSchemaPath(GetMyInfoResponseDto) },
+        },
+      },
+    }),
+    ...createSwaggerAuthErrors(),
+  );
+}

--- a/src/users/presentation/decorators/get-user-analysis-swagger.decorator.ts
+++ b/src/users/presentation/decorators/get-user-analysis-swagger.decorator.ts
@@ -14,11 +14,12 @@ import {
   createSwaggerBadRequest,
   createSwaggerServerErrors,
 } from '@common/utils/swagger-error-response.util';
+
 import {
   FrequentWrongCategoryDto,
   FrequentWrongCommandDto,
   GetUserAnalysisResponseDto,
-} from '../get-user-analysis.dto';
+} from '../dto/get-user-analysis.dto';
 
 export function ApiGetUserAnalysis() {
   return applyDecorators(

--- a/src/users/presentation/dto/get-my-info.dto.ts
+++ b/src/users/presentation/dto/get-my-info.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { plainToInstance } from 'class-transformer';
+
+import { User } from '@users/domain/users.entity';
+
+export class GetMyInfoResponseDto {
+  @ApiProperty({ description: '유저 ID', example: '121' })
+  id: string;
+
+  @ApiProperty({ description: '유지 닉네임', example: 'John' })
+  nickname: string;
+
+  @ApiProperty({
+    description: '유저 프로필 사진 (없을 경우 default image)',
+    example: 'https://example.com/profile.png',
+  })
+  profileImage: string;
+
+  static from(user: User) {
+    return plainToInstance(GetMyInfoResponseDto, {
+      id: user.id.toString(),
+      nickname: user.nickname,
+      profileImage: user.profileImage,
+    });
+  }
+}

--- a/src/users/presentation/dto/get-my-info.dto.ts
+++ b/src/users/presentation/dto/get-my-info.dto.ts
@@ -8,7 +8,7 @@ export class GetMyInfoResponseDto {
   @ApiProperty({ description: '유저 ID', example: '121' })
   id: string;
 
-  @ApiProperty({ description: '유지 닉네임', example: 'John' })
+  @ApiProperty({ description: '유저 닉네임', example: 'John' })
   nickname: string;
 
   @ApiProperty({

--- a/src/users/presentation/dto/get-my-info.dto.ts
+++ b/src/users/presentation/dto/get-my-info.dto.ts
@@ -11,11 +11,12 @@ export class GetMyInfoResponseDto {
   @ApiProperty({ description: '유저 닉네임', example: 'John' })
   nickname: string;
 
+  // FIXME: default profile image 작업 시 string으로 변경
   @ApiProperty({
     description: '유저 프로필 사진 (없을 경우 default image)',
     example: 'https://example.com/profile.png',
   })
-  profileImage: string;
+  profileImage: string | null;
 
   static from(user: User) {
     return plainToInstance(GetMyInfoResponseDto, {

--- a/src/users/presentation/users.controller.spec.ts
+++ b/src/users/presentation/users.controller.spec.ts
@@ -1,17 +1,16 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
-import { Tier } from '@tiers/domain/tiers.entity';
 import {
-  UserMistakeAnalysis,
-  FrequentWrongCommand,
   FrequentWrongCategory,
+  FrequentWrongCommand,
+  UserMistakeAnalysis,
 } from '@games/domain/user-mistake-analysis.entity';
+import { Tier } from '@tiers/domain/tiers.entity';
 
-import { UsersController } from './users.controller';
 import { UsersService } from '../application/users.service';
-
-import { User } from '../domain/users.entity';
 import { CategoryScore, DifficultyScoreDetail, UserStats } from '../domain/user-stats.entity';
+import { User } from '../domain/users.entity';
+import { UsersController } from './users.controller';
 
 function createMockTier(overrides: Partial<Tier> = {}): Tier {
   return Tier.from({
@@ -49,6 +48,7 @@ describe('UsersController', () => {
 
   beforeEach(async () => {
     mockUsersService = {
+      findById: jest.fn(),
       getRanksByPageAndSize: jest.fn(),
       getUserAnalysis: jest.fn(),
       getUserStats: jest.fn(),
@@ -65,6 +65,37 @@ describe('UsersController', () => {
     }).compile();
 
     controller = module.get<UsersController>(UsersController);
+  });
+
+  describe('getMyInfo', () => {
+    const mockUser = createMockUser({
+      id: 1n,
+      nickname: 'John',
+      profileImage: 'https://example.com/profile.png',
+    });
+    const userId = 1n;
+
+    beforeEach(() => {
+      mockUsersService.findById.mockResolvedValue(mockUser);
+    });
+
+    it('조회한 유저의 id, 닉네임, 프로필 이미지가 올바르게 반환되는지 확인', async () => {
+      const result = await controller.getMyInfo({ userId });
+
+      expect(result).toEqual({
+        id: '1',
+        nickname: 'John',
+        profileImage: 'https://example.com/profile.png',
+      });
+    });
+
+    it('유저 조회 중 에러 발생 시 에러 전파하는지 확인', async () => {
+      const expectedError = new Error('Test Error');
+
+      mockUsersService.findById.mockRejectedValue(expectedError);
+
+      await expect(controller.getMyInfo({ userId })).rejects.toThrow(expectedError);
+    });
   });
 
   describe('getRanks', () => {

--- a/src/users/presentation/users.controller.ts
+++ b/src/users/presentation/users.controller.ts
@@ -1,24 +1,35 @@
 import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 
+import { CheckOwnership } from '@auth/presentation/decorators/check-ownership.decorator';
 import { JwtAuthGuard } from '@auth/presentation/guards/jwt-auth.guard';
 import { UserOwnershipGuard } from '@auth/presentation/guards/user-ownership.guard';
-import { CheckOwnership } from '@auth/presentation/decorators/check-ownership.decorator';
+
+import { AuthenticatedUser } from '@/auth/presentation/decorators/authenticated-user.decorator';
 
 import { UsersService } from '../application/users.service';
-
+import { ApiGetMyInfo } from './decorators/get-my-info.swagger.decorator';
+import { ApiGetRanks } from './decorators/get-ranks-swagger.decorator';
+import { ApiGetUserAnalysis } from './decorators/get-user-analysis-swagger.decorator';
+import { ApiGetUserStats } from './decorators/get-user-stats-swagger.decorator';
+import { GetMyInfoResponseDto } from './dto/get-my-info.dto';
 import { GetRanksQueryDto, GetRanksResponseDto } from './dto/get-ranks.dto';
 import { GetUserAnalysisParamDto, GetUserAnalysisResponseDto } from './dto/get-user-analysis.dto';
 import { GetUserStatsParamDto, GetUserStatsResponseDto } from './dto/get-user-stats.dto';
-
-import { ApiGetRanks } from './decorators/get-ranks-swagger.decorator';
-import { ApiGetUserStats } from './decorators/get-user-stats-swagger.decorator';
-import { ApiGetUserAnalysis } from './dto/decorators/get-user-analysis-swagger.decorator';
 
 @ApiTags('Users')
 @Controller('users')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
+
+  @Get('/me')
+  @ApiGetMyInfo()
+  @UseGuards(JwtAuthGuard)
+  async getMyInfo(@AuthenticatedUser() user: { userId: bigint }) {
+    const userInfo = await this.usersService.findById(user.userId);
+
+    return GetMyInfoResponseDto.from(userInfo);
+  }
 
   @Get('/ranks')
   @ApiGetRanks()

--- a/src/users/presentation/users.controller.ts
+++ b/src/users/presentation/users.controller.ts
@@ -1,11 +1,10 @@
 import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 
+import { AuthenticatedUser } from '@auth/presentation/decorators/authenticated-user.decorator';
 import { CheckOwnership } from '@auth/presentation/decorators/check-ownership.decorator';
 import { JwtAuthGuard } from '@auth/presentation/guards/jwt-auth.guard';
 import { UserOwnershipGuard } from '@auth/presentation/guards/user-ownership.guard';
-
-import { AuthenticatedUser } from '@/auth/presentation/decorators/authenticated-user.decorator';
 
 import { UsersService } from '../application/users.service';
 import { ApiGetMyInfo } from './decorators/get-my-info.swagger.decorator';

--- a/test/users/get-my-info.e2e-spec.ts
+++ b/test/users/get-my-info.e2e-spec.ts
@@ -1,0 +1,89 @@
+import { execSync } from 'child_process';
+import { INestApplication } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { PrismaClient } from '@prisma/client';
+import { JwtAuthGuard } from '@auth/presentation/guards/jwt-auth.guard';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { GenericContainer, StartedTestContainer } from 'testcontainers';
+
+import { ApiResponseDto } from '@common/dto/api-response.dto';
+import { ResponseInterceptor } from '@common/interceptors/response.interceptor';
+import { GetMyInfoResponseDto } from '@users/presentation/dto/get-my-info.dto';
+
+import { AppModule } from '../../src/app.module';
+import { createMockAuthGuard } from '../utils/mock-auth.guard';
+
+describe('GET /api/users/me (e2e)', () => {
+  let app: INestApplication<App>;
+  let container: StartedTestContainer;
+
+  beforeAll(async () => {
+    container = await new GenericContainer('postgres:18-alpine')
+      .withExposedPorts(5432)
+      .withEnvironment({
+        POSTGRES_USER: 'test',
+        POSTGRES_PASSWORD: 'test',
+        POSTGRES_DB: 'test',
+      })
+      .start();
+
+    const databaseUrl = `postgresql://test:test@${container.getHost()}:${container.getMappedPort(5432)}/test`;
+    process.env.DATABASE_URL = databaseUrl;
+
+    execSync('npx prisma migrate deploy', {
+      env: { ...process.env, DATABASE_URL: databaseUrl },
+    });
+
+    const prisma = new PrismaClient({ datasourceUrl: databaseUrl });
+
+    await prisma.user.create({
+      data: {
+        email: 'test@test.com',
+        nickname: 'testUser',
+        provider: 'github',
+        providerId: '12345',
+        totalScore: 0n,
+        refreshToken: 'token',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        githubUrl: null,
+        profileImage: 'https://example.com/profile.png',
+        tierId: null,
+      },
+    });
+
+    await prisma.$disconnect();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue(createMockAuthGuard())
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.useGlobalInterceptors(new ResponseInterceptor(app.get(Reflector)));
+
+    await app.init();
+  }, 60000);
+
+  afterAll(async () => {
+    await app?.close();
+    await container?.stop();
+  });
+
+  it('요청한 유저의 id, nickname, profileImage 정보를 응답한다.', async () => {
+    const response = await request(app.getHttpServer()).get('/api/users/me').expect(200);
+    const body = response.body as { data: GetMyInfoResponseDto } & ApiResponseDto;
+
+    expect(body.data).toEqual({
+      id: '1',
+      nickname: 'testUser',
+      profileImage: 'https://example.com/profile.png',
+    });
+  });
+});


### PR DESCRIPTION
# 백엔드 PR

## 📋 변경 사항 요약
- `accessToken` 으로 내 정보를 조회하는 API를 구현했습니다.
- 로그인 이후 클라이언트에서 유저 정보를 조회하기 위해 사용합니다.
<!-- PR의 목적을 간략히 설명 -->

## 🔗 관련 Issue

Closes #45 

- 전체적으로 guard 세팅이 필요해 #35 를 베이스 브랜치로 잡았습니다.

## 🎯 변경 내용

- [ ] `GET /api/users/me` API 구현
  - token 인증된 유저 id로 정보를 조회해 반환 
  - id, nickname, profileImage만 dto에서 변환하여 전달
- [ ] controller, e2e 테스트 코드 작성

## 📌 추가 참고사항
<img width="432" height="292" alt="image" src="https://github.com/user-attachments/assets/e6dab084-98ba-409e-bc95-82d21b773309" />


<img width="417" height="491" alt="image" src="https://github.com/user-attachments/assets/7cb270e5-da42-445c-83b1-a77f614c0b40" />
