### PR TITLE
[Auth] 소셜 로그인 callbackURL에 호스트 주소가 포함되도록 수정

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -2,7 +2,7 @@ name: orvit-server-dev
 
 on:
   push:
-    branches: [feature/issue-49, develop]
+    branches: [develop]
 
 jobs:
   ci:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -2,7 +2,7 @@ name: orvit-server-dev
 
 on:
   push:
-    branches: [develop, feature/issue-49]
+    branches: [feature/issue-49, develop]
 
 jobs:
   ci:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -2,7 +2,7 @@ name: orvit-server-dev
 
 on:
   push:
-    branches: [develop, feature/issue-12]
+    branches: [develop, feature/issue-49]
 
 jobs:
   ci:
@@ -14,14 +14,14 @@ jobs:
 
       - uses: pnpm/action-setup@v3
         with:
-          version: 9 
+          version: 9
 
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 24.x
-          cache: "pnpm"
-          
+          cache: 'pnpm'
+
       - name: Create .env file
         run: |
           printf "PORT=%s\n" "${{ secrets.PORT }}" >> .env
@@ -31,6 +31,7 @@ jobs:
           printf "GITHUB_CLIENT_ID=%s\n" "${{ secrets.CLIENT_ID_FOR_GITHUB }}" >> .env
           printf "GITHUB_CLIENT_SECRET=%s\n" "${{ secrets.CLIENT_SECRET_FOR_GITHUB }}" >> .env
           printf "JWT_TOKEN_SECRET=%s\n" "${{ secrets.JWT_TOKEN_SECRET }}" >> .env
+          printf "SERVER_URL=%s\n" "${{ secrets.SERVER_URL }}" >> .env
 
       - name: Install & Build
         run: |
@@ -71,18 +72,18 @@ jobs:
         run: |
           # OCI CLI 설치
           bash -c "$(curl -L https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh)" -- --accept-all-defaults
-          
+
           # 환경 변수 경로 설정
           echo "/home/runner/bin" >> $GITHUB_PATH
           export PATH=$PATH:/home/runner/bin
-          
+
           # .oci 디렉토리 생성
           mkdir -p ~/.oci
-          
+
           # API 프라이빗 키 파일 생성 (개행 문자 처리를 위해 printf 사용)
           printf "%s" "${{ secrets.OCI_PRIVATE_KEY }}" > ~/.oci/oci_api_key.pem
           chmod 600 ~/.oci/oci_api_key.pem
-          
+
           # 설정 파일(config) 생성
           cat <<EOF > ~/.oci/config
           [DEFAULT]
@@ -123,6 +124,7 @@ jobs:
             echo "GITHUB_CLIENT_ID=${{ secrets.CLIENT_ID_FOR_GITHUB }}" | sudo tee -a .env.dev > /dev/null
             echo "GITHUB_CLIENT_SECRET=${{ secrets.CLIENT_SECRET_FOR_GITHUB }}" | sudo tee -a .env.dev > /dev/null
             echo "JWT_TOKEN_SECRET=${{ secrets.JWT_TOKEN_SECRET }}" | sudo tee -a .env.dev > /dev/null
+            echo "SERVER_URL=${{ secrets.SERVER_URL }}" | sudo tee -a .env.dev > /dev/null
             sudo ./deploy.sh
 
       - name: Close Port 22
@@ -130,7 +132,7 @@ jobs:
         run: |
           RULE_ID=$(~/bin/oci network nsg rules list --nsg-id ${{ secrets.OCI_NSG_ID }} \
             --query "data[?description=='GHA-TEMP-${{ github.run_id }}'].id | [0]" --raw-output)
-          
+
           if [ "$RULE_ID" != "null" ] && [ -n "$RULE_ID" ]; then
             ~/bin/oci network nsg rules remove --nsg-id ${{ secrets.OCI_NSG_ID }} --security-rule-ids "[\"$RULE_ID\"]" 
           fi

--- a/src/auth/presentation/strategies/github.strategy.ts
+++ b/src/auth/presentation/strategies/github.strategy.ts
@@ -1,6 +1,7 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
+
 import { Profile, Strategy } from 'passport-github2';
 
 @Injectable()
@@ -9,7 +10,7 @@ export class GithubStrategy extends PassportStrategy(Strategy, 'github') {
     super({
       clientID: configService.getOrThrow<string>('GITHUB_CLIENT_ID'),
       clientSecret: configService.getOrThrow<string>('GITHUB_CLIENT_SECRET'),
-      callbackURL: '/api/auth/login/github/callback',
+      callbackURL: `${configService.getOrThrow<string>('SERVER_URL')}/api/auth/login/github/callback`,
       scope: ['user:email'],
     });
   }

--- a/src/auth/presentation/strategies/google.strategy.ts
+++ b/src/auth/presentation/strategies/google.strategy.ts
@@ -1,6 +1,7 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
+
 import { Profile, Strategy } from 'passport-google-oauth20';
 
 @Injectable()
@@ -9,7 +10,7 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
     super({
       clientID: configService.getOrThrow<string>('GOOGLE_CLIENT_ID'),
       clientSecret: configService.getOrThrow<string>('GOOGLE_CLIENT_SECRET'),
-      callbackURL: '/api/auth/login/google/callback',
+      callbackURL: `${configService.getOrThrow<string>('SERVER_URL')}/api/auth/login/google/callback`,
       scope: ['email', 'profile'],
     });
   }

--- a/src/config/config.schema.ts
+++ b/src/config/config.schema.ts
@@ -8,4 +8,5 @@ export const configSchema = Joi.object({
   GITHUB_CLIENT_ID: Joi.string().required(),
   GITHUB_CLIENT_SECRET: Joi.string().required(),
   JWT_TOKEN_SECRET: Joi.string().required(),
+  SERVER_URL: Joi.string().required(),
 });


### PR DESCRIPTION
# 백엔드 PR

## 📋 변경 사항 요약

- 소셜 로그인 배포 시 배포된 서버의 주소를 인식하지 못하는 문제가 있어 redirect url mismatch 문제가 있습니다.
- callbackURL 지정 시 호스트 주소를 포함하도록 변경하였습니다.
<!-- PR의 목적을 간략히 설명 -->

## 🔗 관련 Issue

Closes #49 

## 🎯 변경 내용

- [ ] .env에 `SERVER_URL` 추가 (개발 시엔 localhost:3000, 배포 서버는 도메인 주소)
- [ ] `callbackURL` 을 `SERVER_URL`을 포함한 주소로 변경

## 📌 추가 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced OAuth authentication to use configurable server URL for GitHub and Google login callbacks, enabling proper authentication across different deployment environments.

* **Chores**
  * Updated CI/CD workflow to propagate server configuration through deployment stages.
  * Extended configuration schema to require server URL parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->