### PR TITLE
[유저] profile image 없을 경우 기본 이미지 적용

### DIFF
--- a/prisma/seeds/category.seed.ts
+++ b/prisma/seeds/category.seed.ts
@@ -1,9 +1,9 @@
 import { PrismaClient } from '@prisma/client';
 
 const categories = [
-  { name: 'Git', iconUrl: 'https://cdn.orvit.net/categories/git.png' },
-  { name: 'Linux', iconUrl: 'https://cdn.orvit.net/categories/linux.png' },
-  { name: 'Docker', iconUrl: 'https://cdn.orvit.net/categories/docker.png' },
+  { name: 'Git', iconUrl: 'https://cdn.orvit.net/categories/git.webp' },
+  { name: 'Linux', iconUrl: 'https://cdn.orvit.net/categories/linux.webp' },
+  { name: 'Docker', iconUrl: 'https://cdn.orvit.net/categories/docker.webp' },
 ];
 
 export async function seedCategories(prisma: PrismaClient) {

--- a/src/auth/application/auth.facade.spec.ts
+++ b/src/auth/application/auth.facade.spec.ts
@@ -5,6 +5,7 @@ import { GameSessionService } from '@games/application/game-session.service';
 import { TiersService } from '@tiers/application/tiers.service';
 import { Tier } from '@tiers/domain/tiers.entity';
 import { UsersService } from '@users/application/users.service';
+import { DEFAULT_PROFILE_IMAGE } from '@users/domain/user.business-rule';
 import { User } from '@users/domain/users.entity';
 
 import { AuthFacade } from './auth.facade';
@@ -22,7 +23,7 @@ function createMockUser(overrides: Partial<User> = {}): User {
     createdAt: new Date(),
     updatedAt: new Date(),
     githubUrl: null,
-    profileImage: 'https://cdn.orvit.net/users/default_profile.webp',
+    profileImage: DEFAULT_PROFILE_IMAGE,
     tierId: null,
     tier: null,
     ...overrides,

--- a/src/auth/application/auth.facade.spec.ts
+++ b/src/auth/application/auth.facade.spec.ts
@@ -22,7 +22,7 @@ function createMockUser(overrides: Partial<User> = {}): User {
     createdAt: new Date(),
     updatedAt: new Date(),
     githubUrl: null,
-    profileImage: null,
+    profileImage: 'https://cdn.orvit.net/users/default_profile.webp',
     tierId: null,
     tier: null,
     ...overrides,

--- a/src/games/presentation/dto/get-game-options.dto.ts
+++ b/src/games/presentation/dto/get-game-options.dto.ts
@@ -20,7 +20,7 @@ export class CategoryDto {
 
   @ApiProperty({
     description: '카테고리 icon Url',
-    example: 'https://cdn.orvit.net/categories/git.png',
+    example: 'https://cdn.orvit.net/categories/git.webp',
   })
   iconUrl: string;
 }
@@ -30,9 +30,9 @@ export class GetGameOptionsResponseDto {
     description: '게임 카테고리 목록',
     type: [CategoryDto],
     example: [
-      { id: 1, name: 'Git', iconUrl: 'https://cdn.orvit.net/categories/git.png' },
-      { id: 2, name: 'Linux', iconUrl: 'https://cdn.orvit.net/categories/linux.png' },
-      { id: 3, name: 'Docker', iconUrl: 'https://cdn.orvit.net/categories/docker.png' },
+      { id: 1, name: 'Git', iconUrl: 'https://cdn.orvit.net/categories/git.webp' },
+      { id: 2, name: 'Linux', iconUrl: 'https://cdn.orvit.net/categories/linux.webp' },
+      { id: 3, name: 'Docker', iconUrl: 'https://cdn.orvit.net/categories/docker.webp' },
     ],
   })
   categories: CategoryDto[];

--- a/src/users/application/users.service.spec.ts
+++ b/src/users/application/users.service.spec.ts
@@ -9,6 +9,7 @@ import {
 } from '@games/domain/user-mistake-analysis.entity';
 import { Tier } from '@tiers/domain/tiers.entity';
 
+import { DEFAULT_PROFILE_IMAGE } from '../domain/user.business-rule';
 import { User } from '../domain/users.entity';
 import {
   IUsersRepository,
@@ -40,7 +41,7 @@ function createMockUser(overrides: Partial<User> = {}): User {
     createdAt: new Date(),
     updatedAt: new Date(),
     githubUrl: null,
-    profileImage: 'https://cdn.orvit.net/users/default_profile.webp',
+    profileImage: DEFAULT_PROFILE_IMAGE,
     tierId: null,
     tier: null,
     ...overrides,

--- a/src/users/application/users.service.spec.ts
+++ b/src/users/application/users.service.spec.ts
@@ -40,7 +40,7 @@ function createMockUser(overrides: Partial<User> = {}): User {
     createdAt: new Date(),
     updatedAt: new Date(),
     githubUrl: null,
-    profileImage: null,
+    profileImage: 'https://cdn.orvit.net/users/default_profile.webp',
     tierId: null,
     tier: null,
     ...overrides,

--- a/src/users/domain/user.business-rule.ts
+++ b/src/users/domain/user.business-rule.ts
@@ -1,0 +1,4 @@
+/**
+ * default 프로필 사진
+ */
+export const DEFAULT_PROFILE_IMAGE = 'https://cdn.orvit.net/users/default_profile.webp';

--- a/src/users/domain/users.entity.ts
+++ b/src/users/domain/users.entity.ts
@@ -1,5 +1,7 @@
 import { Tier } from '@tiers/domain/tiers.entity';
 
+import { DEFAULT_PROFILE_IMAGE } from './user.business-rule';
+
 export class User {
   constructor(
     public readonly id: bigint,
@@ -12,29 +14,12 @@ export class User {
     public readonly createdAt: Date,
     public readonly updatedAt: Date,
     public readonly githubUrl: string | null,
-    public readonly profileImage: string | null,
+    public readonly profileImage: string,
     public readonly tierId: number | null,
     public readonly tier: Tier | null,
   ) {}
 
-  static from(
-    data: Pick<
-      User,
-      | 'id'
-      | 'email'
-      | 'nickname'
-      | 'provider'
-      | 'providerId'
-      | 'totalScore'
-      | 'refreshToken'
-      | 'createdAt'
-      | 'updatedAt'
-      | 'githubUrl'
-      | 'profileImage'
-      | 'tierId'
-      | 'tier'
-    >,
-  ): User {
+  static from(data: Omit<User, 'profileImage'> & { profileImage: string | null }): User {
     return new User(
       data.id,
       data.email,
@@ -46,7 +31,7 @@ export class User {
       data.createdAt,
       data.updatedAt,
       data.githubUrl,
-      data.profileImage,
+      data.profileImage ?? DEFAULT_PROFILE_IMAGE,
       data.tierId,
       data.tier,
     );

--- a/src/users/presentation/dto/get-my-info.dto.ts
+++ b/src/users/presentation/dto/get-my-info.dto.ts
@@ -2,6 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 
 import { plainToInstance } from 'class-transformer';
 
+import { DEFAULT_PROFILE_IMAGE } from '@users/domain/user.business-rule';
 import { User } from '@users/domain/users.entity';
 
 export class GetMyInfoResponseDto {
@@ -13,7 +14,7 @@ export class GetMyInfoResponseDto {
 
   @ApiProperty({
     description: '유저 프로필 사진 (없을 경우 default image)',
-    example: 'https://cdn.orvit.net/users/default_profile.webp',
+    example: DEFAULT_PROFILE_IMAGE,
   })
   profileImage: string;
 

--- a/src/users/presentation/dto/get-my-info.dto.ts
+++ b/src/users/presentation/dto/get-my-info.dto.ts
@@ -11,12 +11,11 @@ export class GetMyInfoResponseDto {
   @ApiProperty({ description: '유저 닉네임', example: 'John' })
   nickname: string;
 
-  // FIXME: default profile image 작업 시 string으로 변경
   @ApiProperty({
     description: '유저 프로필 사진 (없을 경우 default image)',
-    example: 'https://example.com/profile.png',
+    example: 'https://cdn.orvit.net/users/default_profile.webp',
   })
-  profileImage: string | null;
+  profileImage: string;
 
   static from(user: User) {
     return plainToInstance(GetMyInfoResponseDto, {

--- a/src/users/presentation/dto/get-ranks.dto.ts
+++ b/src/users/presentation/dto/get-ranks.dto.ts
@@ -3,6 +3,8 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { plainToInstance, Type } from 'class-transformer';
 import { IsInt, IsOptional, Min } from 'class-validator';
 
+import { DEFAULT_PROFILE_IMAGE } from '@users/domain/user.business-rule';
+
 import { User } from '../../domain/users.entity';
 
 export class GetRanksQueryDto {
@@ -81,7 +83,7 @@ export class RankItemDto {
 
   @ApiProperty({
     description: '프로필 이미지',
-    example: 'https://cdn.orvit.net/users/default_profile.webp',
+    example: DEFAULT_PROFILE_IMAGE,
   })
   profileImage: string;
 

--- a/src/users/presentation/dto/get-ranks.dto.ts
+++ b/src/users/presentation/dto/get-ranks.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsInt, IsOptional, Min } from 'class-validator';
+
 import { plainToInstance, Type } from 'class-transformer';
+import { IsInt, IsOptional, Min } from 'class-validator';
 
 import { User } from '../../domain/users.entity';
 
@@ -78,8 +79,11 @@ export class RankItemDto {
   @ApiProperty({ description: '총 점수(int size를 넘길 수 있어 string type)', example: '1029342' })
   totalScore: string;
 
-  @ApiProperty({ description: '프로필 이미지', example: 'https://github.com/profile.png' })
-  profileImage: string | null;
+  @ApiProperty({
+    description: '프로필 이미지',
+    example: 'https://cdn.orvit.net/users/default_profile.webp',
+  })
+  profileImage: string;
 
   @ApiProperty({ description: 'github 링크', example: 'https://github.com/user1' })
   githubUrl: string | null;

--- a/src/users/presentation/users.controller.spec.ts
+++ b/src/users/presentation/users.controller.spec.ts
@@ -9,6 +9,7 @@ import { Tier } from '@tiers/domain/tiers.entity';
 
 import { UsersService } from '../application/users.service';
 import { CategoryScore, DifficultyScoreDetail, UserStats } from '../domain/user-stats.entity';
+import { DEFAULT_PROFILE_IMAGE } from '../domain/user.business-rule';
 import { User } from '../domain/users.entity';
 import { UsersController } from './users.controller';
 
@@ -35,7 +36,7 @@ function createMockUser(overrides: Partial<User> = {}): User {
     createdAt: new Date(),
     updatedAt: new Date(),
     githubUrl: null,
-    profileImage: 'https://cdn.orvit.net/users/default_profile.webp',
+    profileImage: DEFAULT_PROFILE_IMAGE,
     tierId: null,
     tier: null,
     ...overrides,

--- a/src/users/presentation/users.controller.spec.ts
+++ b/src/users/presentation/users.controller.spec.ts
@@ -35,7 +35,7 @@ function createMockUser(overrides: Partial<User> = {}): User {
     createdAt: new Date(),
     updatedAt: new Date(),
     githubUrl: null,
-    profileImage: null,
+    profileImage: 'https://cdn.orvit.net/users/default_profile.webp',
     tierId: null,
     tier: null,
     ...overrides,

--- a/test/games/get-game-options.e2e-spec.ts
+++ b/test/games/get-game-options.e2e-spec.ts
@@ -74,17 +74,17 @@ describe('GET /api/games/options (e2e)', () => {
         expect.objectContaining({
           id: 1,
           name: 'Git',
-          iconUrl: 'https://cdn.orvit.net/categories/git.png',
+          iconUrl: 'https://cdn.orvit.net/categories/git.webp',
         }),
         expect.objectContaining({
           id: 2,
           name: 'Linux',
-          iconUrl: 'https://cdn.orvit.net/categories/linux.png',
+          iconUrl: 'https://cdn.orvit.net/categories/linux.webp',
         }),
         expect.objectContaining({
           id: 3,
           name: 'Docker',
-          iconUrl: 'https://cdn.orvit.net/categories/docker.png',
+          iconUrl: 'https://cdn.orvit.net/categories/docker.webp',
         }),
       ]),
     );

--- a/test/users/get-my-info.e2e-spec.ts
+++ b/test/users/get-my-info.e2e-spec.ts
@@ -74,7 +74,7 @@ describe('GET /api/users/me (e2e)', () => {
   afterAll(async () => {
     await app?.close();
     await container?.stop();
-    await prisma.$disconnect();
+    await prisma?.$disconnect();
   });
 
   it('요청한 유저의 id, nickname, profileImage 정보를 응답한다.', async () => {

--- a/test/users/get-my-info.e2e-spec.ts
+++ b/test/users/get-my-info.e2e-spec.ts
@@ -11,6 +11,7 @@ import { GenericContainer, StartedTestContainer } from 'testcontainers';
 
 import { ApiResponseDto } from '@common/dto/api-response.dto';
 import { ResponseInterceptor } from '@common/interceptors/response.interceptor';
+import { DEFAULT_PROFILE_IMAGE } from '@users/domain/user.business-rule';
 import { GetMyInfoResponseDto } from '@users/presentation/dto/get-my-info.dto';
 
 import { AppModule } from '../../src/app.module';
@@ -19,6 +20,7 @@ import { createMockAuthGuard } from '../utils/mock-auth.guard';
 describe('GET /api/users/me (e2e)', () => {
   let app: INestApplication<App>;
   let container: StartedTestContainer;
+  let prisma: PrismaClient;
 
   beforeAll(async () => {
     container = await new GenericContainer('postgres:18-alpine')
@@ -37,7 +39,7 @@ describe('GET /api/users/me (e2e)', () => {
       env: { ...process.env, DATABASE_URL: databaseUrl },
     });
 
-    const prisma = new PrismaClient({ datasourceUrl: databaseUrl });
+    prisma = new PrismaClient({ datasourceUrl: databaseUrl });
 
     await prisma.user.create({
       data: {
@@ -54,8 +56,6 @@ describe('GET /api/users/me (e2e)', () => {
         tierId: null,
       },
     });
-
-    await prisma.$disconnect();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
@@ -74,6 +74,7 @@ describe('GET /api/users/me (e2e)', () => {
   afterAll(async () => {
     await app?.close();
     await container?.stop();
+    await prisma.$disconnect();
   });
 
   it('요청한 유저의 id, nickname, profileImage 정보를 응답한다.', async () => {
@@ -84,6 +85,19 @@ describe('GET /api/users/me (e2e)', () => {
       id: '1',
       nickname: 'testUser',
       profileImage: 'https://example.com/profile.png',
+    });
+  });
+
+  it('profileImage가 없는 유저는 default image로 응답한다.', async () => {
+    await prisma.user.update({ where: { id: 1n }, data: { profileImage: null } });
+
+    const response = await request(app.getHttpServer()).get('/api/users/me').expect(200);
+    const body = response.body as { data: GetMyInfoResponseDto } & ApiResponseDto;
+
+    expect(body.data).toEqual({
+      id: '1',
+      nickname: 'testUser',
+      profileImage: DEFAULT_PROFILE_IMAGE,
     });
   });
 });


### PR DESCRIPTION
# 백엔드 PR

## 📋 변경 사항 요약
- 사용자 기본 프로필 이미지 시안이 제작되어 `profileImage` 필드가 null 일 경우 기본 이미지 주소를 전달하도록 변경했습니다.
- 추가로 category iconUrl 파일 형식을 png -> webp로 변경했습니다. (운영 DB에 반영 완료)

<!-- PR의 목적을 간략히 설명 -->

## 🔗 관련 Issue

Closes #33 

## 🎯 변경 내용

- [ ] `user.business-rule.ts` 내 기본 프로필 이미지 주소 저장 
- [ ] `User` 엔티티에서 `profileImage` 가 없는 경우 기본 이미지 주소로 변환
- [ ] 관련된 테스트 코드 수정 
- [ ] `get-my-info` 내 정보 조회 e2e 테스트 시 profile default image 변환 관련 검증 케이스 추가
- [ ] 카테고리 iconUrl 테스트 seed 파일등에서 webp 사용하도록 변경

## 📌 추가 참고사항
<img width="601" height="293" alt="image" src="https://github.com/user-attachments/assets/92afd8a0-6a20-4ad1-9855-bb0bbf069aeb" />

- FE에서 webp 형식 말씀해주셔서 webp로 저장해두었습니다.
- Default 이미지 - https://cdn.orvit.net/users/default_profile.webp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Users now always have a non-null profile image; when none is set, a default app image is used so profile images display consistently.

* **Documentation**
  * API examples updated to show the default profile image URL.

* **Tests**
  * Tests and end-to-end checks added/updated to verify fallback to the default profile image.

* **Data / UI Samples**
  * Category and game option icons updated to use .webp image URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->