### PR TITLE
[Auth] 소셜 로그인 토큰 발급 방식을 Auth Code 방식으로 수정

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -31,6 +31,7 @@ jobs:
           printf "GITHUB_CLIENT_ID=%s\n" "${{ secrets.CLIENT_ID_FOR_GITHUB }}" >> .env
           printf "GITHUB_CLIENT_SECRET=%s\n" "${{ secrets.CLIENT_SECRET_FOR_GITHUB }}" >> .env
           printf "JWT_TOKEN_SECRET=%s\n" "${{ secrets.JWT_TOKEN_SECRET }}" >> .env
+          printf "JWT_AUTH_CODE_SECRET=%s\n" "${{ secrets.JWT_AUTH_CODE_SECRET }}" >> .env
           printf "SERVER_URL=%s\n" "${{ secrets.SERVER_URL }}" >> .env
 
       - name: Install & Build
@@ -124,6 +125,7 @@ jobs:
             echo "GITHUB_CLIENT_ID=${{ secrets.CLIENT_ID_FOR_GITHUB }}" | sudo tee -a .env.dev > /dev/null
             echo "GITHUB_CLIENT_SECRET=${{ secrets.CLIENT_SECRET_FOR_GITHUB }}" | sudo tee -a .env.dev > /dev/null
             echo "JWT_TOKEN_SECRET=${{ secrets.JWT_TOKEN_SECRET }}" | sudo tee -a .env.dev > /dev/null
+            echo "JWT_AUTH_CODE_SECRET=${{ secrets.JWT_AUTH_CODE_SECRET }}" | sudo tee -a .env.dev > /dev/null
             echo "SERVER_URL=${{ secrets.SERVER_URL }}" | sudo tee -a .env.dev > /dev/null
             sudo ./deploy.sh
 

--- a/src/auth/application/auth.facade.spec.ts
+++ b/src/auth/application/auth.facade.spec.ts
@@ -54,6 +54,8 @@ describe('AuthFacade', () => {
           useValue: {
             issueTokens: jest.fn(),
             verifyRefreshTokenWithSavedToken: jest.fn(),
+            createTemporalAuthorizationCode: jest.fn(),
+            verifyAuthorizationCode: jest.fn(),
           },
         },
         {
@@ -89,104 +91,87 @@ describe('AuthFacade', () => {
     tiersService.getLowestTier.mockResolvedValue(lowestTier);
   });
 
-  it('기존 유저면 refreshToken을 갱신하고 토큰을 반환한다', async () => {
-    const existingUser = createMockUser({ id: 10n, email: 'hello@test.com' });
-    usersService.findByEmail.mockResolvedValue(existingUser);
-    authService.issueTokens.mockReturnValue({
-      accessToken: 'access-token',
-      refreshToken: 'refresh-token',
-    });
-    usersService.updateRefreshToken.mockResolvedValue(existingUser);
+  describe('processSocialLogin', () => {
+    it('기존 유저는 새로 생성하지 않고 userId를 반환한다', async () => {
+      const existingUser = createMockUser({ id: 10n, email: 'hello@test.com' });
+      usersService.findByEmail.mockResolvedValue(existingUser);
 
-    const result = await facade.processSocialLogin({
-      provider: 'github',
-      socialUser: {
-        id: 'provider-1',
-        email: existingUser.email,
-        nickname: 'nickname',
-      },
-    });
+      const result = await facade.processSocialLogin({
+        provider: 'github',
+        socialUser: {
+          id: 'provider-1',
+          email: existingUser.email,
+          nickname: 'nickname',
+        },
+      });
 
-    expect(authService.issueTokens).toHaveBeenCalledWith(10n);
-    expect(tiersService.getLowestTier).not.toHaveBeenCalled();
-    expect(usersService.updateRefreshToken).toHaveBeenCalledWith(10n, 'refresh-token');
-    expect(usersService.createSocialUser).not.toHaveBeenCalled();
-    expect(gameSessionService.attachUserToSession).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      accessToken: 'access-token',
-      refreshToken: 'refresh-token',
-    });
-  });
-
-  it('신규 유저 + gameSessionId이면 유저 생성 후 세션을 연결한다', async () => {
-    usersService.findByEmail.mockResolvedValue(null);
-    authService.issueTokens.mockReturnValue({
-      accessToken: 'new-access-token',
-      refreshToken: 'new-refresh-token',
+      expect(result).toEqual({ userId: 10n });
+      expect(usersService.createSocialUser).not.toHaveBeenCalled();
     });
 
-    const createdUser = createMockUser({
-      id: 99n,
-      email: 'new@test.com',
-      nickname: 'newbie',
-      refreshToken: '',
-    });
-    usersService.createSocialUser.mockResolvedValue(createdUser);
-    const result = await facade.processSocialLogin({
-      provider: 'github',
-      socialUser: {
-        id: 'github-user-id',
+    it('신규 유저 + gameSessionId이면 유저 생성 후 세션을 연결하고 userId를 반환한다', async () => {
+      usersService.findByEmail.mockResolvedValue(null);
+
+      const createdUser = createMockUser({
+        id: 99n,
         email: 'new@test.com',
         nickname: 'newbie',
+        refreshToken: '',
+      });
+      usersService.createSocialUser.mockResolvedValue(createdUser);
+      const result = await facade.processSocialLogin({
+        provider: 'github',
+        socialUser: {
+          id: 'github-user-id',
+          email: 'new@test.com',
+          nickname: 'newbie',
+          profileImage: 'https://example.com/profile.png',
+          githubUrl: 'https://github.com/newbie',
+        },
+        gameSessionId: 777n,
+      });
+
+      expect(usersService.createSocialUser).toHaveBeenCalledWith({
+        email: 'new@test.com',
+        nickname: 'newbie',
+        provider: 'github',
+        providerId: 'github-user-id',
         profileImage: 'https://example.com/profile.png',
         githubUrl: 'https://github.com/newbie',
-      },
-      gameSessionId: 777n,
+        refreshToken: '',
+        tierId: 1,
+      });
+      expect(gameSessionService.attachUserToSession).toHaveBeenCalledWith(777n, 99n);
+      expect(authService.issueTokens).not.toHaveBeenCalled();
+      expect(result).toEqual({ userId: 99n });
     });
 
-    expect(usersService.createSocialUser).toHaveBeenCalledWith({
-      email: 'new@test.com',
-      nickname: 'newbie',
-      provider: 'github',
-      providerId: 'github-user-id',
-      profileImage: 'https://example.com/profile.png',
-      githubUrl: 'https://github.com/newbie',
-      refreshToken: '',
-      tierId: 1,
-    });
-    expect(gameSessionService.attachUserToSession).toHaveBeenCalledWith(777n, 99n);
-    expect(authService.issueTokens).toHaveBeenCalledWith(99n);
-    expect(result).toEqual({
-      accessToken: 'new-access-token',
-      refreshToken: 'new-refresh-token',
-    });
-  });
+    it('신규 유저 + gameSessionId 없음이면 세션 연결을 생략한다', async () => {
+      usersService.findByEmail.mockResolvedValue(null);
+      authService.issueTokens.mockReturnValue({
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+      });
 
-  it('신규 유저 + gameSessionId 없음이면 세션 연결을 생략한다', async () => {
-    usersService.findByEmail.mockResolvedValue(null);
-    authService.issueTokens.mockReturnValue({
-      accessToken: 'access-token',
-      refreshToken: 'refresh-token',
-    });
-
-    const createdUser = createMockUser({
-      id: 55n,
-      email: 'new2@test.com',
-      nickname: 'new2',
-      refreshToken: '',
-    });
-    usersService.createSocialUser.mockResolvedValue(createdUser);
-
-    await facade.processSocialLogin({
-      provider: 'google',
-      socialUser: {
-        id: 'google-user-id',
+      const createdUser = createMockUser({
+        id: 55n,
         email: 'new2@test.com',
         nickname: 'new2',
-      },
-    });
+        refreshToken: '',
+      });
+      usersService.createSocialUser.mockResolvedValue(createdUser);
 
-    expect(gameSessionService.attachUserToSession).not.toHaveBeenCalled();
+      await facade.processSocialLogin({
+        provider: 'google',
+        socialUser: {
+          id: 'google-user-id',
+          email: 'new2@test.com',
+          nickname: 'new2',
+        },
+      });
+
+      expect(gameSessionService.attachUserToSession).not.toHaveBeenCalled();
+    });
   });
 
   describe('processRefreshTokens', () => {
@@ -216,6 +201,47 @@ describe('AuthFacade', () => {
       await expect(facade.processRefreshTokens(userId)).rejects.toThrow(error);
 
       expect(usersService.updateRefreshToken).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('generateTemporalAuthorizationCode', () => {
+    it('인증 코드 발급 서비스 함수에 userId를 전달하고 발급한 토큰을 반환한다', () => {
+      const userId = 42n;
+      authService.createTemporalAuthorizationCode.mockReturnValue('auth.code.jwt');
+
+      const result = facade.generateTemporalAuthorizationCode(userId);
+
+      expect(authService.createTemporalAuthorizationCode).toHaveBeenCalledWith(userId);
+      expect(result).toBe('auth.code.jwt');
+    });
+  });
+
+  describe('exchangeAuthorizationCode', () => {
+    it('유효한 코드를 검증한 후 토큰을 발급하고 갱신 토큰을 저장한다', async () => {
+      const userId = 10n;
+      const tokens = { accessToken: 'access-token', refreshToken: 'refresh-token' };
+
+      authService.verifyAuthorizationCode.mockReturnValue(userId);
+      authService.issueTokens.mockReturnValue(tokens);
+      usersService.updateRefreshToken.mockResolvedValue(createMockUser({ id: userId }));
+
+      const result = await facade.exchangeAuthorizationCode('valid.code');
+
+      expect(authService.verifyAuthorizationCode).toHaveBeenCalledWith('valid.code');
+      expect(authService.issueTokens).toHaveBeenCalledWith(userId);
+      expect(usersService.updateRefreshToken).toHaveBeenCalledWith(userId, tokens.refreshToken);
+      expect(result).toEqual(tokens);
+    });
+
+    it('코드 검증이 실패하면 예외를 전파하고 토큰 발급은 하지 않는다', async () => {
+      const error = new UnauthorizedException('유효하지 않은 인가 코드입니다.');
+      authService.verifyAuthorizationCode.mockImplementation(() => {
+        throw error;
+      });
+
+      await expect(facade.exchangeAuthorizationCode('invalid.code')).rejects.toThrow(error);
+
+      expect(authService.issueTokens).not.toHaveBeenCalled();
     });
   });
 

--- a/src/auth/application/auth.facade.ts
+++ b/src/auth/application/auth.facade.ts
@@ -20,6 +20,24 @@ export class AuthFacade {
   ) {}
 
   /**
+   * @description 토큰 발급 인증용 임시 코드 발급
+   */
+  generateTemporalAuthorizationCode(userId: bigint): string {
+    return this.authService.createTemporalAuthorizationCode(userId);
+  }
+
+  /**
+   * @description 인증용 임시 코드 검증 후 access, refresh token 발급
+   */
+  async exchangeAuthorizationCode(
+    code: string,
+  ): Promise<{ accessToken: string; refreshToken: string }> {
+    const userId = this.authService.verifyAuthorizationCode(code);
+
+    return this.loginExistingUser(userId);
+  }
+
+  /**
    * @description 유효한 refreshToken인지 검증
    */
   async verifyRefreshToken(userId: bigint, refreshToken: string): Promise<void> {
@@ -31,7 +49,9 @@ export class AuthFacade {
   /**
    * @description 기존 유저 로그인 플로우를 통한 토큰 갱신
    */
-  async processRefreshTokens(userId: bigint): Promise<ProcessSocialLoginFacadeResponseDto> {
+  async processRefreshTokens(
+    userId: bigint,
+  ): Promise<{ accessToken: string; refreshToken: string }> {
     return this.loginExistingUser(userId);
   }
 
@@ -44,7 +64,7 @@ export class AuthFacade {
     const existingUser = await this.usersService.findByEmail(loginData.socialUser.email);
 
     if (existingUser) {
-      return this.loginExistingUser(existingUser.id);
+      return { userId: existingUser.id };
     }
 
     return this.registerNewSocialUser(loginData);
@@ -57,7 +77,12 @@ export class AuthFacade {
     return this.usersService.isExistUser(userId);
   }
 
-  private async loginExistingUser(userId: bigint): Promise<ProcessSocialLoginFacadeResponseDto> {
+  /**
+   * @description 기존 유저 로그인 처리 (신규 토큰 발급 및 업데이트)
+   */
+  private async loginExistingUser(
+    userId: bigint,
+  ): Promise<{ accessToken: string; refreshToken: string }> {
     const tokens = this.authService.issueTokens(userId);
 
     await this.usersService.updateRefreshToken(userId, tokens.refreshToken);
@@ -88,12 +113,7 @@ export class AuthFacade {
 
     await this.attachGameSessionIfExists(loginData.gameSessionId, createdUser.id);
 
-    const tokens = this.authService.issueTokens(createdUser.id);
-    await this.usersService.updateRefreshToken(createdUser.id, tokens.refreshToken);
-
-    return {
-      ...tokens,
-    };
+    return { userId: createdUser.id };
   }
 
   /**

--- a/src/auth/application/auth.service.spec.ts
+++ b/src/auth/application/auth.service.spec.ts
@@ -1,0 +1,108 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { AuthService } from './auth.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let jwtService: JwtService;
+
+  const JWT_TOKEN_SECRET = 'test-jwt-token-secret';
+  const JWT_AUTH_CODE_SECRET = 'test-auth-code-secret';
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        {
+          provide: JwtService,
+          useValue: new JwtService({ secret: JWT_TOKEN_SECRET }),
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            getOrThrow: jest.fn((key: string) => {
+              if (key === 'JWT_AUTH_CODE_SECRET') return JWT_AUTH_CODE_SECRET;
+
+              throw new Error(`Unknown config key: ${key}`);
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+    jwtService = module.get<JwtService>(JwtService);
+  });
+
+  describe('issueTokens', () => {
+    it('userId로 accessToken과 refreshToken을 발급한다', () => {
+      const result = service.issueTokens(1n);
+
+      expect(typeof result.accessToken).toBe('string');
+      expect(typeof result.refreshToken).toBe('string');
+    });
+  });
+
+  describe('createTemporalAuthorizationCode', () => {
+    it('발급한 인증 코드를 반환한다', () => {
+      const code = service.createTemporalAuthorizationCode(42n);
+
+      expect(typeof code).toBe('string');
+    });
+  });
+
+  describe('verifyAuthorizationCode', () => {
+    it('유효한 인증 코드 검증 후 userId를 bigint로 반환한다', () => {
+      const code = service.createTemporalAuthorizationCode(99n);
+
+      const result = service.verifyAuthorizationCode(code);
+
+      expect(result).toBe(99n);
+    });
+
+    it('type이 auth_code가 아닌 JWT는 UnauthorizedException을 던진다', () => {
+      const codeWithWrongType = jwtService.sign(
+        { sub: '1', type: 'access_token' },
+        { expiresIn: '1m', secret: JWT_AUTH_CODE_SECRET },
+      );
+
+      expect(() => service.verifyAuthorizationCode(codeWithWrongType)).toThrow(
+        new UnauthorizedException('유효하지 않은 인가 코드입니다.'),
+      );
+    });
+
+    it('잘못된 시크릿으로 서명된 코드는 UnauthorizedException을 던진다', () => {
+      const codeWithWrongSecret = jwtService.sign(
+        { sub: '1', type: 'auth_code' },
+        { expiresIn: '1m', secret: 'wrong-secret' },
+      );
+
+      expect(() => service.verifyAuthorizationCode(codeWithWrongSecret)).toThrow(
+        new UnauthorizedException('유효하지 않은 인가 코드입니다.'),
+      );
+    });
+  });
+
+  describe('verifyRefreshTokenWithSavedToken', () => {
+    it('요청 토큰과 저장 토큰이 일치하면 예외 없이 통과한다', () => {
+      expect(() =>
+        service.verifyRefreshTokenWithSavedToken('same-token', 'same-token'),
+      ).not.toThrow();
+    });
+
+    it('요청 토큰과 저장 토큰이 다르면 UnauthorizedException을 던진다', () => {
+      expect(() =>
+        service.verifyRefreshTokenWithSavedToken('request-token', 'saved-token'),
+      ).toThrow(new UnauthorizedException('유효하지 않은 토큰입니다.'));
+    });
+
+    it('길이가 다른 토큰이면 UnauthorizedException을 던진다', () => {
+      expect(() => service.verifyRefreshTokenWithSavedToken('short', 'much-longer-token')).toThrow(
+        new UnauthorizedException('유효하지 않은 토큰입니다.'),
+      );
+    });
+  });
+});

--- a/src/auth/application/auth.service.ts
+++ b/src/auth/application/auth.service.ts
@@ -1,17 +1,23 @@
 import { timingSafeEqual } from 'crypto';
 import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
-
-import { ProcessSocialLoginFacadeResponseDto } from './service-dto/process-social-login.service-dto';
 
 @Injectable()
 export class AuthService {
-  constructor(private readonly jwtService: JwtService) {}
+  private readonly authCodeSecret: string;
+
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+  ) {
+    this.authCodeSecret = this.configService.getOrThrow<string>('JWT_AUTH_CODE_SECRET');
+  }
 
   /**
    * @description access, refresh token 발급
    */
-  issueTokens(userId: bigint): ProcessSocialLoginFacadeResponseDto {
+  issueTokens(userId: bigint): { accessToken: string; refreshToken: string } {
     return {
       accessToken: this.createAccessToken(userId),
       refreshToken: this.createRefreshToken(userId),
@@ -44,6 +50,40 @@ export class AuthService {
         expiresIn: '14d',
       },
     );
+  }
+
+  /**
+   * @description temporal authorization code token 생성
+   */
+  createTemporalAuthorizationCode(userId: bigint): string {
+    return this.jwtService.sign(
+      {
+        sub: userId.toString(),
+        type: 'auth_code',
+      },
+      { expiresIn: '1m', secret: this.authCodeSecret },
+    );
+  }
+
+  /**
+   * @description 임시 인가 코드 jwt 검증 후 userId 반환
+   */
+  verifyAuthorizationCode(code: string): bigint {
+    let payload: { sub: string; type: string };
+
+    try {
+      payload = this.jwtService.verify<{ sub: string; type: string }>(code, {
+        secret: this.authCodeSecret,
+      });
+    } catch {
+      throw new UnauthorizedException('유효하지 않은 인가 코드입니다.');
+    }
+
+    if (payload.type !== 'auth_code') {
+      throw new UnauthorizedException('유효하지 않은 인가 코드입니다.');
+    }
+
+    return BigInt(payload.sub);
   }
 
   /**

--- a/src/auth/application/service-dto/process-social-login.service-dto.ts
+++ b/src/auth/application/service-dto/process-social-login.service-dto.ts
@@ -13,6 +13,5 @@ export interface ProcessSocialLoginFacadeRequestDto {
 }
 
 export interface ProcessSocialLoginFacadeResponseDto {
-  accessToken: string;
-  refreshToken: string;
+  userId: bigint;
 }

--- a/src/auth/presentation/auth.controller.spec.ts
+++ b/src/auth/presentation/auth.controller.spec.ts
@@ -1,7 +1,11 @@
-import { Request, Response } from 'express';
+import { Response } from 'express';
 
 import { AuthFacade } from '../application/auth.facade';
 import { AuthController } from './auth.controller';
+import { GetTokensQueryDto, GetTokensResponseDto } from './dto/get-tokens.dto';
+import { RefreshTokensResponseDto } from './dto/refresh-tokens.dto';
+import { OAuthCallbackRequest } from './types/auth.type';
+import { encodeOAuthState } from './utils/oauth-state.util';
 
 describe('AuthController', () => {
   let controller: AuthController;
@@ -10,48 +14,159 @@ describe('AuthController', () => {
   beforeEach(() => {
     authFacade = {
       processRefreshTokens: jest.fn(),
+      processSocialLogin: jest.fn(),
+      generateTemporalAuthorizationCode: jest.fn(),
+      exchangeAuthorizationCode: jest.fn(),
     } as unknown as jest.Mocked<AuthFacade>;
 
     controller = new AuthController(authFacade);
   });
 
-  const createMockResponse = (): Pick<Response, 'status' | 'cookie' | 'json'> => {
-    const response = {
-      status: jest.fn().mockReturnThis(),
-      cookie: jest.fn().mockReturnThis(),
-      json: jest.fn(),
-    };
+  const createMockResponse = (): Pick<Response, 'redirect'> => ({
+    redirect: jest.fn(),
+  });
 
-    return response;
-  };
+  const createOAuthCallbackRequest = (overrides: Partial<OAuthCallbackRequest> = {}) =>
+    ({
+      query: {},
+      user: {
+        id: 'provider-id',
+        email: 'user@example.com',
+        nickname: 'testUser',
+      },
+      ...overrides,
+    }) as unknown as OAuthCallbackRequest;
 
   describe('refreshTokens', () => {
-    it('토큰 갱신 성공 시 setAuthCookies를 호출하고 200 응답한다', async () => {
-      const response = createMockResponse();
-      const setAuthCookiesSpy = jest
-        .spyOn(controller as unknown as { setAuthCookies: jest.Mock }, 'setAuthCookies')
-        .mockImplementation(() => {});
+    it('토큰 갱신 성공 시 새 토큰을 응답 DTO로 반환한다', async () => {
+      const tokens = { accessToken: 'new-access', refreshToken: 'new-refresh' };
+      authFacade.processRefreshTokens.mockResolvedValue(tokens);
 
-      authFacade.processRefreshTokens.mockResolvedValue({
-        accessToken: 'access-token',
-        refreshToken: 'refresh-token',
-      });
+      const result = await controller.refreshTokens({ userId: 10n });
 
-      await controller.refreshTokens({} as Request, response as Response, { userId: 10n });
-
-      expect(setAuthCookiesSpy).toHaveBeenCalledWith(response, 'access-token', 'refresh-token');
-      expect(response.status).toHaveBeenCalledWith(200);
-      expect(response.json).toHaveBeenCalledWith({ statusCode: 200, success: true });
+      expect(authFacade.processRefreshTokens).toHaveBeenCalledWith(10n);
+      expect(result).toEqual(RefreshTokensResponseDto.from(tokens));
     });
 
     it('토큰 갱신 처리 중 에러가 발생하면 예외를 전파한다', async () => {
-      const response = createMockResponse();
       const expectedError = new Error('refresh failed');
       authFacade.processRefreshTokens.mockRejectedValue(expectedError);
 
-      await expect(
-        controller.refreshTokens({} as Request, response as Response, { userId: 10n }),
-      ).rejects.toThrow(expectedError);
+      await expect(controller.refreshTokens({ userId: 10n })).rejects.toThrow(expectedError);
+    });
+  });
+
+  describe('getTokens', () => {
+    it('유효한 인증 코드로 accessToken과 refreshToken을 반환한다', async () => {
+      const tokens = { accessToken: 'access-token', refreshToken: 'refresh-token' };
+      authFacade.exchangeAuthorizationCode.mockResolvedValue(tokens);
+
+      const query: GetTokensQueryDto = { code: 'valid.auth.code' };
+      const result = await controller.getTokens(query);
+
+      expect(authFacade.exchangeAuthorizationCode).toHaveBeenCalledWith('valid.auth.code');
+      expect(result).toEqual(GetTokensResponseDto.from(tokens));
+    });
+
+    it('인증 코드 교환 실패 시 예외를 전파한다', async () => {
+      const error = new Error('invalid code');
+      authFacade.exchangeAuthorizationCode.mockRejectedValue(error);
+
+      await expect(controller.getTokens({ code: 'bad.code' })).rejects.toThrow(error);
+    });
+  });
+
+  describe('googleAuthCallback', () => {
+    it('OAuth 로그인 성공 시 redirectUrl에 code 쿼리 파라미터를 포함하여 리다이렉트한다', async () => {
+      const res = createMockResponse();
+      const redirectUrl = 'http://localhost:3000/callback';
+
+      authFacade.processSocialLogin.mockResolvedValue({ userId: 42n });
+      authFacade.generateTemporalAuthorizationCode.mockReturnValue('auth.code.jwt');
+
+      const req = createOAuthCallbackRequest({
+        query: { state: encodeOAuthState({ redirectUrl }) },
+      });
+
+      await controller.googleAuthCallback(req, res as Response);
+
+      expect(authFacade.generateTemporalAuthorizationCode).toHaveBeenCalledWith(42n);
+      expect(res.redirect).toHaveBeenCalledWith(
+        'http://localhost:3000/callback?code=auth.code.jwt',
+      );
+    });
+
+    it('state에 gameSessionId가 포함되어 있으면 processSocialLogin에 bigint로 전달한다', async () => {
+      const res = createMockResponse();
+      authFacade.processSocialLogin.mockResolvedValue({ userId: 10n });
+      authFacade.generateTemporalAuthorizationCode.mockReturnValue('code');
+
+      const req = createOAuthCallbackRequest({
+        query: {
+          state: encodeOAuthState({
+            redirectUrl: 'http://localhost:3000',
+            gameSessionId: '999',
+          }),
+        },
+      });
+
+      await controller.googleAuthCallback(req, res as Response);
+
+      expect(authFacade.processSocialLogin).toHaveBeenCalledWith(
+        expect.objectContaining({ gameSessionId: 999n }),
+      );
+    });
+
+    it('state가 없으면 기본 경로(/)에 code 쿼리 파라미터를 포함하여 리다이렉트한다', async () => {
+      const res = createMockResponse();
+      authFacade.processSocialLogin.mockResolvedValue({ userId: 5n });
+      authFacade.generateTemporalAuthorizationCode.mockReturnValue('code');
+
+      const req = createOAuthCallbackRequest({ query: {} });
+
+      await controller.googleAuthCallback(req, res as Response);
+
+      expect(res.redirect).toHaveBeenCalledWith('/?code=code');
+    });
+
+    it('로그인 처리 중 에러가 발생하면 기본 경로(/)로 리다이렉트한다', async () => {
+      const res = createMockResponse();
+      authFacade.processSocialLogin.mockRejectedValue(new Error('login failed'));
+
+      const req = createOAuthCallbackRequest();
+
+      await controller.googleAuthCallback(req, res as Response);
+
+      expect(res.redirect).toHaveBeenCalledWith('/');
+    });
+  });
+
+  describe('githubAuthCallback', () => {
+    it('OAuth 로그인 성공 시 redirectUrl에 code 쿼리 파라미터를 포함하여 리다이렉트한다', async () => {
+      const res = createMockResponse();
+      const redirectUrl = 'http://localhost:3000/callback';
+
+      authFacade.processSocialLogin.mockResolvedValue({ userId: 77n });
+      authFacade.generateTemporalAuthorizationCode.mockReturnValue('github.code.jwt');
+
+      const req = createOAuthCallbackRequest({
+        query: { state: encodeOAuthState({ redirectUrl }) },
+      });
+
+      await controller.githubAuthCallback(req, res as Response);
+
+      expect(res.redirect).toHaveBeenCalledWith(
+        'http://localhost:3000/callback?code=github.code.jwt',
+      );
+    });
+
+    it('로그인 처리 중 에러가 발생하면 기본 경로(/)로 리다이렉트한다', async () => {
+      const res = createMockResponse();
+      authFacade.processSocialLogin.mockRejectedValue(new Error('github login failed'));
+
+      await controller.githubAuthCallback(createOAuthCallbackRequest(), res as Response);
+
+      expect(res.redirect).toHaveBeenCalledWith('/');
     });
   });
 });

--- a/src/auth/presentation/auth.controller.ts
+++ b/src/auth/presentation/auth.controller.ts
@@ -1,16 +1,29 @@
-import { Controller, Get, Logger, Post, Req, Res, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  HttpCode,
+  Logger,
+  Post,
+  Query,
+  Req,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 
-import { Request, Response } from 'express';
+import { Response } from 'express';
 
 import { AuthFacade } from '../application/auth.facade';
 import { SocialLoginProvider } from '../domain/auth.business-rule';
 import { AuthenticatedUser } from './decorators/authenticated-user.decorator';
+import { ApiGetTokens } from './decorators/get-tokens-swagger.decorator';
 import { ApiGithubLoginCallback } from './decorators/github-login-callback-swagger.decorator';
 import { ApiGoogleLoginCallback } from './decorators/google-login-callback-swagger.decorator';
 import { ApiLoginByGithub } from './decorators/login-by-github-swagger.decorator';
 import { ApiLoginByGoogle } from './decorators/login-by-google-swagger.decorator';
 import { ApiRefreshTokens } from './decorators/refresh-tokens-swagger.decorator';
+import { GetTokensQueryDto, GetTokensResponseDto } from './dto/get-tokens.dto';
+import { RefreshTokensResponseDto } from './dto/refresh-tokens.dto';
 import { GithubAuthGuard } from './guards/github-auth.guard';
 import { GoogleAuthGuard } from './guards/google-auth.guard';
 import { JwtRefreshAuthGuard } from './guards/jwt-refresh-auth.guard';
@@ -49,20 +62,30 @@ export class AuthController {
   }
 
   @Post('refresh')
+  @HttpCode(200)
   @UseGuards(JwtRefreshAuthGuard)
   @ApiRefreshTokens()
   async refreshTokens(
-    @Req() req: Request,
-    @Res() res: Response,
     @AuthenticatedUser() user: { userId: bigint },
-  ): Promise<void> {
-    const { accessToken, refreshToken } = await this.authFacade.processRefreshTokens(user.userId);
+  ): Promise<RefreshTokensResponseDto> {
+    const tokens = await this.authFacade.processRefreshTokens(user.userId);
 
-    this.setAuthCookies(res, accessToken, refreshToken);
-
-    res.status(200).json({ statusCode: 200, success: true });
+    return RefreshTokensResponseDto.from(tokens);
   }
 
+  @Get('token')
+  @ApiGetTokens()
+  async getTokens(@Query() query: GetTokensQueryDto): Promise<GetTokensResponseDto> {
+    const tokens = await this.authFacade.exchangeAuthorizationCode(query.code);
+
+    return GetTokensResponseDto.from(tokens);
+  }
+
+  /**
+   * @description oauth callback 처리 핸들러
+   * - 실제 유저 로그인, 회원 가입 진행
+   * - 토큰 발급을 위한 임시 인증 코드 생성 후 redirect 처리
+   */
   private async handleOAuthCallback(
     req: OAuthCallbackRequest,
     res: Response,
@@ -71,21 +94,25 @@ export class AuthController {
     try {
       const { redirectUrl, gameSessionId } = this.parseOAuthCallbackState(req.query.state);
 
-      const { accessToken, refreshToken } = await this.authFacade.processSocialLogin({
+      const { userId } = await this.authFacade.processSocialLogin({
         provider,
         socialUser: req.user,
         gameSessionId,
       });
 
-      this.setAuthCookies(res, accessToken, refreshToken);
+      const code = this.authFacade.generateTemporalAuthorizationCode(userId);
+      const redirectUrlWithCode = this.buildRedirectUrlWithCode(redirectUrl, code);
 
-      res.redirect(redirectUrl);
+      res.redirect(redirectUrlWithCode);
     } catch {
       this.logger.warn(`[${provider}] 로그인 처리 실패, 기본 경로로 리다이렉트`);
       res.redirect('/');
     }
   }
 
+  /**
+   * @description OAuth callback state 객체 decode
+   */
   private parseOAuthCallbackState(stateEncoded?: string): {
     redirectUrl: string;
     gameSessionId: bigint | undefined;
@@ -111,38 +138,19 @@ export class AuthController {
     };
   }
 
-  private setAuthCookies(res: Response, accessToken: string, refreshToken: string): void {
-    const isProd = process.env.NODE_ENV === 'production';
+  /**
+   * @description 로그인 redirectUrl에 code 쿼리 스트링 연결
+   */
+  private buildRedirectUrlWithCode(redirectUrl: string, code: string): string {
+    try {
+      const url = new URL(redirectUrl);
+      url.searchParams.set('code', code);
 
-    this.setRefreshTokenCookie(res, refreshToken, isProd);
-    this.setAccessTokenCookie(res, accessToken, isProd);
-  }
+      return url.toString();
+    } catch {
+      const separator = redirectUrl.includes('?') ? '&' : '?';
 
-  private setRefreshTokenCookie(res: Response, refreshToken: string, isProd: boolean): void {
-    if (!refreshToken) {
-      return;
+      return `${redirectUrl}${separator}code=${code}`;
     }
-
-    res.cookie('refreshToken', refreshToken, {
-      httpOnly: true,
-      secure: isProd,
-      sameSite: 'lax',
-      path: '/',
-      maxAge: 14 * 24 * 60 * 60 * 1000,
-    });
-  }
-
-  private setAccessTokenCookie(res: Response, accessToken: string, isProd: boolean): void {
-    if (!accessToken) {
-      return;
-    }
-
-    res.cookie('accessToken', accessToken, {
-      httpOnly: false,
-      secure: isProd,
-      sameSite: 'lax',
-      path: '/',
-      maxAge: 1 * 60 * 60 * 1000,
-    });
   }
 }

--- a/src/auth/presentation/decorators/get-tokens-swagger.decorator.ts
+++ b/src/auth/presentation/decorators/get-tokens-swagger.decorator.ts
@@ -1,0 +1,39 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiExtraModels, ApiOkResponse, ApiOperation, getSchemaPath } from '@nestjs/swagger';
+
+import { ApiResponseDto } from '@/common/dto/api-response.dto';
+import {
+  createSwaggerBadRequest,
+  createSwaggerServerErrors,
+  createSwaggerUnauthorized,
+} from '@/common/utils/swagger-error-response.util';
+
+import { GetTokensResponseDto } from '../dto/get-tokens.dto';
+
+export function ApiGetTokens() {
+  return applyDecorators(
+    ApiOperation({ summary: '인증용 코드로 토큰 발급' }),
+    ApiExtraModels(ApiResponseDto, GetTokensResponseDto),
+    ApiOkResponse({
+      description: '토큰 발급 성공',
+      schema: {
+        type: 'object',
+        $ref: getSchemaPath(ApiResponseDto),
+        properties: {
+          data: { $ref: getSchemaPath(GetTokensResponseDto) },
+        },
+      },
+    }),
+    createSwaggerBadRequest([
+      { description: 'code 필수 누락', message: 'code는 필수 값입니다.' },
+      { description: '잘못된 code 형식', message: 'code가 유효한 토큰 형식이 아닙니다.' },
+    ]),
+    createSwaggerUnauthorized([
+      {
+        description: '코드 검증 실패',
+        message: '유효하지 않은 인가 코드입니다.',
+      },
+    ]),
+    ...createSwaggerServerErrors(),
+  );
+}

--- a/src/auth/presentation/decorators/github-login-callback-swagger.decorator.ts
+++ b/src/auth/presentation/decorators/github-login-callback-swagger.decorator.ts
@@ -23,12 +23,8 @@ export function ApiGithubLoginCallback() {
     }),
     ApiResponse({
       status: 302,
-      description: '로그인 성공 시 state.redirectUrl로, 실패 시 / 경로로 리다이렉트',
-      headers: {
-        'Set-Cookie': {
-          description: 'accessToken, refreshToken이 Set-Cookie 헤더로 내려감',
-        },
-      },
+      description:
+        '로그인 성공 시 state.redirectUrl?code=<1분간 유효한 인가코드> 로, 실패 시 / 경로로 리다이렉트',
     }),
     createSwaggerUnauthorized([
       {

--- a/src/auth/presentation/decorators/google-login-callback-swagger.decorator.ts
+++ b/src/auth/presentation/decorators/google-login-callback-swagger.decorator.ts
@@ -23,12 +23,8 @@ export function ApiGoogleLoginCallback() {
     }),
     ApiResponse({
       status: 302,
-      description: '로그인 성공 시 state.redirectUrl로, 실패 시 / 경로로 리다이렉트',
-      headers: {
-        'Set-Cookie': {
-          description: 'accessToken, refreshToken이 Set-Cookie 헤더로 내려감',
-        },
-      },
+      description:
+        '로그인 성공 시 state.redirectUrl?code=<1분간 유효한 인가코드> 로, 실패 시 / 경로로 리다이렉트',
     }),
     createSwaggerUnauthorized([
       {

--- a/src/auth/presentation/decorators/refresh-tokens-swagger.decorator.ts
+++ b/src/auth/presentation/decorators/refresh-tokens-swagger.decorator.ts
@@ -1,10 +1,19 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiBody, ApiOkResponse, ApiOperation } from '@nestjs/swagger';
+import {
+  ApiBody,
+  ApiExtraModels,
+  ApiOkResponse,
+  ApiOperation,
+  getSchemaPath,
+} from '@nestjs/swagger';
 
+import { ApiResponseDto } from '@/common/dto/api-response.dto';
 import {
   createSwaggerServerErrors,
   createSwaggerUnauthorized,
 } from '@common/utils/swagger-error-response.util';
+
+import { RefreshTokensResponseDto } from '../dto/refresh-tokens.dto';
 
 export function ApiRefreshTokens() {
   return applyDecorators(
@@ -23,19 +32,14 @@ export function ApiRefreshTokens() {
         required: ['refreshToken'],
       },
     }),
+    ApiExtraModels(ApiResponseDto, RefreshTokensResponseDto),
     ApiOkResponse({
       description: '리프레시 토큰 갱신 성공',
-      headers: {
-        'Set-Cookie': {
-          description: 'accessToken, refreshToken이 Set-Cookie 헤더로 내려감',
-        },
-      },
-      content: {
-        'application/json': {
-          example: {
-            statusCode: 200,
-            success: true,
-          },
+      schema: {
+        type: 'object',
+        $ref: getSchemaPath(ApiResponseDto),
+        properties: {
+          data: { $ref: getSchemaPath(RefreshTokensResponseDto) },
         },
       },
     }),

--- a/src/auth/presentation/dto/get-tokens.dto.ts
+++ b/src/auth/presentation/dto/get-tokens.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { plainToInstance } from 'class-transformer';
+import { IsJWT, IsNotEmpty } from 'class-validator';
+
+export class GetTokensQueryDto {
+  @ApiProperty({ description: '로그인 리다이렉트 시 포함된 인증용 코드', example: 'eyhjewo...' })
+  @IsNotEmpty({ message: 'code는 필수 값입니다.' })
+  @IsJWT({ message: 'code가 유효한 토큰 형식이 아닙니다.' })
+  code: string;
+}
+
+export class GetTokensResponseDto {
+  @ApiProperty({ description: 'access token', example: 'eyhjewo...' })
+  accessToken: string;
+
+  @ApiProperty({ description: 'refresh token', example: 'eyhjewo...' })
+  refreshToken: string;
+
+  static from(tokens: { accessToken: string; refreshToken: string }) {
+    return plainToInstance(GetTokensResponseDto, tokens);
+  }
+}

--- a/src/auth/presentation/dto/refresh-tokens.dto.ts
+++ b/src/auth/presentation/dto/refresh-tokens.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { plainToInstance } from 'class-transformer';
+
+export class RefreshTokensResponseDto {
+  @ApiProperty({ description: 'access token', example: 'eyhjewo...' })
+  accessToken: string;
+
+  @ApiProperty({ description: 'refresh token', example: 'eyhjewo...' })
+  refreshToken: string;
+
+  static from(tokens: { accessToken: string; refreshToken: string }) {
+    return plainToInstance(RefreshTokensResponseDto, tokens);
+  }
+}

--- a/src/config/config.schema.ts
+++ b/src/config/config.schema.ts
@@ -8,5 +8,6 @@ export const configSchema = Joi.object({
   GITHUB_CLIENT_ID: Joi.string().required(),
   GITHUB_CLIENT_SECRET: Joi.string().required(),
   JWT_TOKEN_SECRET: Joi.string().required(),
+  JWT_AUTH_CODE_SECRET: Joi.string().required(),
   SERVER_URL: Joi.string().required(),
 });

--- a/test/auth/get-tokens.e2e-spec.ts
+++ b/test/auth/get-tokens.e2e-spec.ts
@@ -1,0 +1,131 @@
+import { execSync } from 'child_process';
+import { INestApplication } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { JwtService } from '@nestjs/jwt';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { PrismaClient } from '@prisma/client';
+import { AuthService } from '@auth/application/auth.service';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { GenericContainer, StartedTestContainer } from 'testcontainers';
+
+import { ResponseInterceptor } from '@common/interceptors/response.interceptor';
+
+import { AppModule } from '../../src/app.module';
+
+interface GetTokensApiResponse {
+  statusCode: number;
+  success: boolean;
+  message?: string;
+  data?: {
+    accessToken: string;
+    refreshToken: string;
+  };
+}
+
+describe('GET /api/auth/token (e2e)', () => {
+  let app: INestApplication<App>;
+  let container: StartedTestContainer;
+  let authService: AuthService;
+  let jwtService: JwtService;
+  let validAuthCode: string;
+
+  const TEST_USER_EMAIL = 'get-tokens-e2e-user@example.com';
+
+  beforeAll(async () => {
+    container = await new GenericContainer('postgres:18-alpine')
+      .withExposedPorts(5432)
+      .withEnvironment({
+        POSTGRES_USER: 'test',
+        POSTGRES_PASSWORD: 'test',
+        POSTGRES_DB: 'test',
+      })
+      .start();
+
+    const databaseUrl = `postgresql://test:test@${container.getHost()}:${container.getMappedPort(5432)}/test`;
+    process.env.DATABASE_URL = databaseUrl;
+
+    execSync('npx prisma migrate deploy', {
+      env: { ...process.env, DATABASE_URL: databaseUrl },
+    });
+
+    const prisma = new PrismaClient({ datasourceUrl: databaseUrl });
+
+    const user = await prisma.user.create({
+      data: {
+        email: TEST_USER_EMAIL,
+        nickname: 'Get Tokens E2E User',
+        provider: 'local',
+        providerId: 'get-tokens-e2e-user',
+        profileImage: null,
+        githubUrl: null,
+        refreshToken: '',
+      },
+    });
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.useGlobalInterceptors(new ResponseInterceptor(app.get(Reflector)));
+
+    authService = app.get(AuthService);
+    jwtService = app.get(JwtService);
+    validAuthCode = authService.createTemporalAuthorizationCode(user.id);
+
+    await app.init();
+  }, 60000);
+
+  afterAll(async () => {
+    await app?.close();
+    await container?.stop();
+  });
+
+  it('유효한 인증 코드로 요청하면 200과 함께 accessToken과 refreshToken을 반환한다', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/api/auth/token')
+      .query({ code: validAuthCode })
+      .expect(200);
+
+    const body = response.body as GetTokensApiResponse;
+    expect(body.statusCode).toBe(200);
+    expect(body.success).toBe(true);
+    expect(typeof body.data?.accessToken).toBe('string');
+    expect(typeof body.data?.refreshToken).toBe('string');
+  });
+
+  it('잘못된 시크릿으로 서명된 코드로 요청하면 401을 반환한다', async () => {
+    const codeWithWrongSecret = jwtService.sign(
+      { sub: '1', type: 'auth_code' },
+      { expiresIn: '1m', secret: 'wrong-secret' },
+    );
+
+    const response = await request(app.getHttpServer())
+      .get('/api/auth/token')
+      .query({ code: codeWithWrongSecret })
+      .expect(401);
+
+    const body = response.body as GetTokensApiResponse;
+    expect(body.success).toBe(false);
+  });
+
+  it('JWT 형식이 아닌 code로 요청하면 400을 반환한다', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/api/auth/token')
+      .query({ code: 'not-a-jwt-string' })
+      .expect(400);
+
+    const body = response.body as GetTokensApiResponse;
+    expect(body.success).toBe(false);
+  });
+
+  it('code 파라미터 없이 요청하면 400을 반환한다', async () => {
+    const response = await request(app.getHttpServer()).get('/api/auth/token').expect(400);
+
+    const body = response.body as GetTokensApiResponse;
+    expect(body.success).toBe(false);
+  });
+});

--- a/test/auth/refresh-tokens.e2e-spec.ts
+++ b/test/auth/refresh-tokens.e2e-spec.ts
@@ -17,6 +17,10 @@ interface RefreshTokensApiResponse {
   statusCode: number;
   success: boolean;
   message?: string;
+  data?: {
+    accessToken: string;
+    refreshToken: string;
+  };
 }
 
 describe('POST /api/auth/refresh (e2e)', () => {
@@ -82,7 +86,7 @@ describe('POST /api/auth/refresh (e2e)', () => {
     await container?.stop();
   });
 
-  it('유효한 refreshToken으로 요청하면 200과 함께 쿠키를 갱신한다', async () => {
+  it('유효한 refreshToken으로 요청하면 200과 함께 새 accessToken과 refreshToken을 반환한다', async () => {
     const response = await request(app.getHttpServer())
       .post('/api/auth/refresh')
       .send({ refreshToken: validRefreshToken })
@@ -91,18 +95,8 @@ describe('POST /api/auth/refresh (e2e)', () => {
     const body = response.body as RefreshTokensApiResponse;
     expect(body.statusCode).toBe(200);
     expect(body.success).toBe(true);
-
-    const setCookieValue = response.headers['set-cookie'];
-    const setCookieHeader = typeof setCookieValue === 'string' ? [setCookieValue] : setCookieValue;
-
-    const hasAccessTokenCookie = setCookieHeader?.some((cookie) =>
-      cookie.startsWith('accessToken='),
-    );
-    const hasRefreshTokenCookie = setCookieHeader?.some((cookie) =>
-      cookie.startsWith('refreshToken='),
-    );
-    expect(hasAccessTokenCookie).toBe(true);
-    expect(hasRefreshTokenCookie).toBe(true);
+    expect(typeof body.data?.accessToken).toBe('string');
+    expect(typeof body.data?.refreshToken).toBe('string');
   });
 
   it('DB에 저장된 토큰과 불일치하면 401을 반환한다', async () => {


### PR DESCRIPTION
# 백엔드 PR

## 📋 변경 사항 요약
- 로그인 시 기존 cookie 방식은 브라우저 단에서 same-site가 아닐 경우 읽기 어렵고 보안상 문제가 있음
- cookie를 읽지 않고 서버로 바로 포함해 전송시키려는 방법은 현재 FE Next.js SSR 구조에서 처리하기 어려운 문제가 있음
 
=> 따라서 cookie 전달 방식을 제거하고, 임시 authorization code 를 통한 별도 토큰 반환 API 요청하도록 플로우 수정
<!-- PR의 목적을 간략히 설명 -->

## 🔗 관련 Issue

Closes #57 

## 🎯 변경 내용

- [ ] 소셜 로그인 토큰 응답 방식 수정
    - `res.cookie` 에 세팅하는 방식 제거
    - redirect 시 미리 발급한 `code`를 query string에 포함시켜 응답
    - 인증 코드는 유효기간이 1분으로 짧은 jwt token으로 secret key 값을 기존 access/refresh 토큰과 다르게 설정하여 보안성 강화
- [ ] 인증 code로 토큰 발급용 API 추가  
    - `GET /api/auth/token?code=` API 추가
    - 인증 코드 검증 후 access token, refresh token을 발급해 `res.body`로 json 응답
- [ ] 리프레시 토큰 갱신 API 응답 값 수정
     - `res.cookie` 에 갱신하는 방식 제거
     - `res.body`에 json 형식으로 응답하도록 수정
- [ ] 기타 변경 사항
     - 작업 내용에 해당하는 테스트 코드 수정 및 추가
     - e2e 테스트 작성 (get-tokens)
     - 기존 로그인 swagger 명세에 쿠키 내용 제거, 리다이렉트 코드 설명 추가

## 📌 추가 참고사항
<img width="435" height="210" alt="image" src="https://github.com/user-attachments/assets/418a8cde-a584-4dc7-92b2-860be6927cd5" />

<img width="443" height="635" alt="image" src="https://github.com/user-attachments/assets/0c3eaade-e33a-4484-8abe-aeb158bc83cf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented authorization code flow for secure token exchange
  * Added new token retrieval endpoint for exchanging authorization codes into access and refresh tokens
  * OAuth login callbacks now redirect with temporary authorization codes (valid for 1 minute)

* **Behavioral Changes**
  * Token refresh endpoint now returns tokens in the response body instead of setting cookies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->