### PR TITLE
[유저] 랭킹 티어 필터링 시 서버에서 현재 유저 티어 기준으로 조회하도록 수정

### DIFF
--- a/src/auth/presentation/decorators/get-tokens-swagger.decorator.ts
+++ b/src/auth/presentation/decorators/get-tokens-swagger.decorator.ts
@@ -1,12 +1,12 @@
 import { applyDecorators } from '@nestjs/common';
 import { ApiExtraModels, ApiOkResponse, ApiOperation, getSchemaPath } from '@nestjs/swagger';
 
-import { ApiResponseDto } from '@/common/dto/api-response.dto';
+import { ApiResponseDto } from '@common/dto/api-response.dto';
 import {
   createSwaggerBadRequest,
   createSwaggerServerErrors,
   createSwaggerUnauthorized,
-} from '@/common/utils/swagger-error-response.util';
+} from '@common/utils/swagger-error-response.util';
 
 import { GetTokensResponseDto } from '../dto/get-tokens.dto';
 

--- a/src/auth/presentation/decorators/refresh-tokens-swagger.decorator.ts
+++ b/src/auth/presentation/decorators/refresh-tokens-swagger.decorator.ts
@@ -7,7 +7,7 @@ import {
   getSchemaPath,
 } from '@nestjs/swagger';
 
-import { ApiResponseDto } from '@/common/dto/api-response.dto';
+import { ApiResponseDto } from '@common/dto/api-response.dto';
 import {
   createSwaggerServerErrors,
   createSwaggerUnauthorized,

--- a/src/auth/presentation/strategies/jwt-refresh.strategy.spec.ts
+++ b/src/auth/presentation/strategies/jwt-refresh.strategy.spec.ts
@@ -1,9 +1,8 @@
 import { UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
+import { AuthFacade } from '@auth/application/auth.facade';
 import { Request } from 'express';
-
-import { AuthFacade } from '@/auth/application/auth.facade';
 
 import { JwtRefreshStrategy } from './jwt-refresh.strategy';
 

--- a/src/games/infrastructure/games.repository.ts
+++ b/src/games/infrastructure/games.repository.ts
@@ -2,8 +2,8 @@ import { Injectable, Logger } from '@nestjs/common';
 
 import { Prisma } from '@prisma/client';
 
-import { PrismaService } from '@/prisma/prisma.service';
 import { capitalize } from '@common/utils/string.util';
+import { PrismaService } from '@prisma/prisma.service';
 
 import { GameCategory } from '../domain/game-categories.entity';
 import { ClientAnswerInput } from '../domain/game-client-answers.interface';

--- a/src/users/application/users.service.spec.ts
+++ b/src/users/application/users.service.spec.ts
@@ -1,4 +1,4 @@
-import { NotFoundException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { GamesService } from '@games/application/games.service';
@@ -9,7 +9,7 @@ import {
 } from '@games/domain/user-mistake-analysis.entity';
 import { Tier } from '@tiers/domain/tiers.entity';
 
-import { DEFAULT_PROFILE_IMAGE } from '../domain/user.business-rule';
+import { DEFAULT_PROFILE_IMAGE, RankScope } from '../domain/user.business-rule';
 import { User } from '../domain/users.entity';
 import {
   IUsersRepository,
@@ -105,35 +105,38 @@ describe('UsersService', () => {
       mockUsersRepository.countAll.mockResolvedValue(mockUsers.length);
     });
 
-    it('파라미터 정보로 유저 목록 조회하는지 확인', async () => {
+    it('scope가 all이면 tierId 없이 유저 목록을 조회하는지 확인', async () => {
       const page = 2;
       const size = 10;
 
-      await service.getRanksByPageAndSize(page, size);
+      await service.getRanksByPageAndSize(page, size, RankScope.All);
 
       expect(mockUsersRepository.findAllOrderByScoreDesc).toHaveBeenCalledWith(
         page,
         size,
         undefined,
       );
+      expect(mockUsersRepository.countAll).toHaveBeenCalledWith(undefined);
     });
 
-    it('파라미터 정보로 전체 개수 조회하는지 확인', async () => {
-      const page = 2;
-      const size = 10;
-      const tierId = 1;
+    it('scope가 tier이고 userId가 없으면 ForbiddenException을 던지는지 확인', async () => {
+      await expect(service.getRanksByPageAndSize(1, 10, RankScope.Tier)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
 
-      await service.getRanksByPageAndSize(page, size, tierId);
+    it('scope가 tier이면 유저의 tierId로 목록을 조회하는지 확인', async () => {
+      const tierId = 3;
+      mockUsersRepository.findByIdWithTier.mockResolvedValue(createMockUser({ tierId }));
 
+      await service.getRanksByPageAndSize(1, 10, RankScope.Tier, 1n);
+
+      expect(mockUsersRepository.findAllOrderByScoreDesc).toHaveBeenCalledWith(1, 10, tierId);
       expect(mockUsersRepository.countAll).toHaveBeenCalledWith(tierId);
     });
 
     it('유저 목록과 개수 정보를 튜플로 반환하는지 확인', async () => {
-      const page = 2;
-      const size = 10;
-      const tierId = 1;
-
-      const ret = await service.getRanksByPageAndSize(page, size, tierId);
+      const ret = await service.getRanksByPageAndSize(1, 10, RankScope.All);
 
       expect(ret).toEqual([mockUsers, mockUsers.length]);
     });

--- a/src/users/application/users.service.ts
+++ b/src/users/application/users.service.ts
@@ -35,7 +35,7 @@ export class UsersService {
     userId?: bigint,
   ): Promise<[User[], number]> {
     if (scope === RankScope.Tier && !userId) {
-      throw new ForbiddenException('티어 랭킹 조회는 회원만 가능합니다');
+      throw new ForbiddenException('티어 랭킹 조회는 회원만 가능합니다.');
     }
 
     const tierId =

--- a/src/users/application/users.service.ts
+++ b/src/users/application/users.service.ts
@@ -1,10 +1,11 @@
-import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 
 import { GamesService } from '@games/application/games.service';
 import { UserMistakeAnalysis } from '@games/domain/user-mistake-analysis.entity';
 
 import { UserStats } from '../domain/user-stats.entity';
 import { UserStatsMapper } from '../domain/user-stats.mapper';
+import { RankScope } from '../domain/user.business-rule';
 import { User } from '../domain/users.entity';
 import { IUsersRepository, USER_REPOSITORY } from '../domain/users.repository.interface';
 
@@ -30,8 +31,18 @@ export class UsersService {
   async getRanksByPageAndSize(
     page: number,
     size: number,
-    tierId?: number,
+    scope: RankScope,
+    userId?: bigint,
   ): Promise<[User[], number]> {
+    if (scope === RankScope.Tier && !userId) {
+      throw new ForbiddenException('티어 랭킹 조회는 회원만 가능합니다');
+    }
+
+    const tierId =
+      scope === RankScope.Tier && userId
+        ? ((await this.findById(userId)).tierId ?? undefined)
+        : undefined;
+
     return Promise.all([
       this.usersRepository.findAllOrderByScoreDesc(page, size, tierId),
       this.usersRepository.countAll(tierId),

--- a/src/users/domain/user.business-rule.ts
+++ b/src/users/domain/user.business-rule.ts
@@ -2,3 +2,11 @@
  * default 프로필 사진
  */
 export const DEFAULT_PROFILE_IMAGE = 'https://cdn.orvit.net/users/default_profile.webp';
+
+/**
+ * 랭킹 조회 범위
+ */
+export enum RankScope {
+  All = 'all',
+  Tier = 'tier',
+}

--- a/src/users/infrastructure/users.repository.ts
+++ b/src/users/infrastructure/users.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
-import { PrismaService } from '@/prisma/prisma.service';
+import { PrismaService } from '@prisma/prisma.service';
 
 import { User } from '../domain/users.entity';
 import { IUsersRepository, ScoreDetailOriginData } from '../domain/users.repository.interface';

--- a/src/users/presentation/decorators/get-ranks-swagger.decorator.ts
+++ b/src/users/presentation/decorators/get-ranks-swagger.decorator.ts
@@ -1,13 +1,13 @@
 import { applyDecorators } from '@nestjs/common';
-import {
-  ApiExtraModels,
-  ApiOkResponse,
-  ApiOperation,
-  ApiResponse,
-  getSchemaPath,
-} from '@nestjs/swagger';
+import { ApiExtraModels, ApiOkResponse, ApiOperation, getSchemaPath } from '@nestjs/swagger';
 
+import {
+  createSwaggerBadRequest,
+  createSwaggerForbidden,
+  createSwaggerServerErrors,
+} from '@/common/utils/swagger-error-response.util';
 import { ApiResponseDto } from '@common/dto/api-response.dto';
+
 import { GetRanksResponseDto } from '../dto/get-ranks.dto';
 
 export function ApiGetRanks() {
@@ -24,17 +24,16 @@ export function ApiGetRanks() {
         },
       },
     }),
-    ApiResponse({
-      status: 400,
-      description: 'Validation Failed (e.g. Query string, Body, Params)',
-    }),
-    ApiResponse({
-      status: 500,
-      description: 'Internal Server Error',
-    }),
-    ApiResponse({
-      status: 503,
-      description: 'Service Unavailable',
-    }),
+    createSwaggerBadRequest([
+      { description: 'page가 정수 아님', message: 'page가 정수가 아닙니다.' },
+      { description: 'page 최솟값 미만', message: 'page의 최솟값은 1입니다.' },
+      { description: 'size가 정수 아님', message: 'size가 정수가 아닙니다.' },
+      { description: 'size 최솟값 미만', message: 'size의 최솟값은 1입니다.' },
+      { description: 'scope 값 오류', message: '랭킹 scope는 tier, all 중 하나여야 합니다.' },
+    ]),
+    createSwaggerForbidden([
+      { description: '조회 권한 오류', message: '티어 랭킹 조회는 회원만 가능합니다.' },
+    ]),
+    ...createSwaggerServerErrors(),
   );
 }

--- a/src/users/presentation/decorators/get-ranks-swagger.decorator.ts
+++ b/src/users/presentation/decorators/get-ranks-swagger.decorator.ts
@@ -1,12 +1,12 @@
 import { applyDecorators } from '@nestjs/common';
 import { ApiExtraModels, ApiOkResponse, ApiOperation, getSchemaPath } from '@nestjs/swagger';
 
+import { ApiResponseDto } from '@common/dto/api-response.dto';
 import {
   createSwaggerBadRequest,
   createSwaggerForbidden,
   createSwaggerServerErrors,
-} from '@/common/utils/swagger-error-response.util';
-import { ApiResponseDto } from '@common/dto/api-response.dto';
+} from '@common/utils/swagger-error-response.util';
 
 import { GetRanksResponseDto } from '../dto/get-ranks.dto';
 

--- a/src/users/presentation/dto/get-ranks.dto.ts
+++ b/src/users/presentation/dto/get-ranks.dto.ts
@@ -1,9 +1,9 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
 
 import { plainToInstance, Type } from 'class-transformer';
-import { IsInt, IsOptional, Min } from 'class-validator';
+import { IsEnum, IsInt, Min } from 'class-validator';
 
-import { DEFAULT_PROFILE_IMAGE } from '@users/domain/user.business-rule';
+import { DEFAULT_PROFILE_IMAGE, RankScope } from '@users/domain/user.business-rule';
 
 import { User } from '../../domain/users.entity';
 
@@ -14,8 +14,8 @@ export class GetRanksQueryDto {
     default: 1,
     required: true,
   })
-  @IsInt()
-  @Min(1)
+  @IsInt({ message: 'page가 정수가 아닙니다.' })
+  @Min(1, { message: 'page의 최솟값은 1입니다.' })
   @Type(() => Number)
   page: number = 1;
 
@@ -25,19 +25,19 @@ export class GetRanksQueryDto {
     default: 20,
     required: true,
   })
-  @IsInt()
-  @Min(1)
+  @IsInt({ message: 'size가 정수가 아닙니다.' })
+  @Min(1, { message: 'size의 최솟값은 1입니다.' })
   @Type(() => Number)
   size: number = 20;
 
-  @ApiPropertyOptional({
-    description: '특정 티어 ID 필터링 (없으면 전체 조회)',
-    example: 3,
+  @ApiProperty({
+    description: '랭킹 필터링 범위 (기본 전체 조회)',
+    example: 'tier',
+    default: 'all',
+    required: false,
   })
-  @IsOptional()
-  @IsInt()
-  @Type(() => Number)
-  tierId?: number;
+  @IsEnum(RankScope, { message: '랭킹 scope는 tier, all 중 하나여야 합니다.' })
+  scope: RankScope = RankScope.All;
 }
 
 export class PaginationMetadataDto {

--- a/src/users/presentation/users.controller.spec.ts
+++ b/src/users/presentation/users.controller.spec.ts
@@ -9,7 +9,7 @@ import { Tier } from '@tiers/domain/tiers.entity';
 
 import { UsersService } from '../application/users.service';
 import { CategoryScore, DifficultyScoreDetail, UserStats } from '../domain/user-stats.entity';
-import { DEFAULT_PROFILE_IMAGE } from '../domain/user.business-rule';
+import { DEFAULT_PROFILE_IMAGE, RankScope } from '../domain/user.business-rule';
 import { User } from '../domain/users.entity';
 import { UsersController } from './users.controller';
 
@@ -102,30 +102,49 @@ describe('UsersController', () => {
   describe('getRanks', () => {
     const mockTier = createMockTier({ name: 'gold' });
     let mockUsers: User[];
-    let query: { page: number; size: number; tierId?: number };
 
     beforeEach(() => {
       mockUsers = [
         createMockUser({ nickname: 'user1', totalScore: 100n, tier: mockTier }),
         createMockUser({ nickname: 'user2', totalScore: 90n, tier: mockTier }),
       ];
-      query = { page: 1, size: 20 };
 
       mockUsersService.getRanksByPageAndSize.mockResolvedValue([mockUsers, mockUsers.length]);
     });
 
-    it('서비스를 호출하여 랭킹 데이터를 조회하는지 확인', async () => {
-      await controller.getRanks(query);
+    it('scope와 userId를 서비스에 전달하는지 확인', async () => {
+      const query = { page: 1, size: 20, scope: RankScope.All };
+      const user = { userId: undefined };
+
+      await controller.getRanks(query, user);
 
       expect(mockUsersService.getRanksByPageAndSize).toHaveBeenCalledWith(
-        query.page,
-        query.size,
+        1,
+        20,
+        RankScope.All,
         undefined,
       );
     });
 
+    it('로그인 유저의 userId를 서비스에 전달하는지 확인', async () => {
+      const query = { page: 1, size: 20, scope: RankScope.Tier };
+      const user = { userId: 1n };
+
+      await controller.getRanks(query, user);
+
+      expect(mockUsersService.getRanksByPageAndSize).toHaveBeenCalledWith(
+        1,
+        20,
+        RankScope.Tier,
+        1n,
+      );
+    });
+
     it('유저 목록에 랭킹 정보가 같이 반환되는지 확인', async () => {
-      const result = await controller.getRanks(query);
+      const result = await controller.getRanks(
+        { page: 1, size: 20, scope: RankScope.All },
+        { userId: undefined },
+      );
 
       expect(result.ranks).toHaveLength(2);
       expect(result.ranks[0].ranking).toBe(1);
@@ -135,7 +154,10 @@ describe('UsersController', () => {
     });
 
     it('페이지네이션 메타데이터 정보가 반환되는지 확인', async () => {
-      const result = await controller.getRanks(query);
+      const result = await controller.getRanks(
+        { page: 1, size: 20, scope: RankScope.All },
+        { userId: undefined },
+      );
 
       expect(result.metadata).toEqual({
         page: 1,
@@ -143,18 +165,6 @@ describe('UsersController', () => {
         totalItems: 2,
         totalPage: 1,
       });
-    });
-
-    it('tierId가 있으면 서비스에 전달한다', async () => {
-      query.tierId = 3;
-
-      await controller.getRanks(query);
-
-      expect(mockUsersService.getRanksByPageAndSize).toHaveBeenCalledWith(
-        query.page,
-        query.size,
-        3,
-      );
     });
   });
 

--- a/src/users/presentation/users.controller.ts
+++ b/src/users/presentation/users.controller.ts
@@ -4,9 +4,8 @@ import { ApiTags } from '@nestjs/swagger';
 import { AuthenticatedUser } from '@auth/presentation/decorators/authenticated-user.decorator';
 import { CheckOwnership } from '@auth/presentation/decorators/check-ownership.decorator';
 import { JwtAuthGuard } from '@auth/presentation/guards/jwt-auth.guard';
+import { OptionalJwtAuthGuard } from '@auth/presentation/guards/optional-jwt-auth.guard';
 import { UserOwnershipGuard } from '@auth/presentation/guards/user-ownership.guard';
-
-import { OptionalJwtAuthGuard } from '@/auth/presentation/guards/optional-jwt-auth.guard';
 
 import { UsersService } from '../application/users.service';
 import { ApiGetMyInfo } from './decorators/get-my-info.swagger.decorator';

--- a/src/users/presentation/users.controller.ts
+++ b/src/users/presentation/users.controller.ts
@@ -6,6 +6,8 @@ import { CheckOwnership } from '@auth/presentation/decorators/check-ownership.de
 import { JwtAuthGuard } from '@auth/presentation/guards/jwt-auth.guard';
 import { UserOwnershipGuard } from '@auth/presentation/guards/user-ownership.guard';
 
+import { OptionalJwtAuthGuard } from '@/auth/presentation/guards/optional-jwt-auth.guard';
+
 import { UsersService } from '../application/users.service';
 import { ApiGetMyInfo } from './decorators/get-my-info.swagger.decorator';
 import { ApiGetRanks } from './decorators/get-ranks-swagger.decorator';
@@ -30,12 +32,25 @@ export class UsersController {
     return GetMyInfoResponseDto.from(userInfo);
   }
 
+  /**
+   * @description 전체 유저, 티어별 랭킹 조회
+   * - 티어별 랭킹 조회는 회원만 가능
+   */
   @Get('/ranks')
+  @UseGuards(OptionalJwtAuthGuard)
   @ApiGetRanks()
-  async getRanks(@Query() query: GetRanksQueryDto): Promise<GetRanksResponseDto> {
-    const { page, size, tierId } = query;
+  async getRanks(
+    @Query() query: GetRanksQueryDto,
+    @AuthenticatedUser() user: { userId?: bigint },
+  ): Promise<GetRanksResponseDto> {
+    const { page, size, scope } = query;
 
-    const [users, totalItems] = await this.usersService.getRanksByPageAndSize(page, size, tierId);
+    const [users, totalItems] = await this.usersService.getRanksByPageAndSize(
+      page,
+      size,
+      scope,
+      user?.userId,
+    );
 
     return GetRanksResponseDto.from(users, totalItems, page, size);
   }

--- a/test/users/get-ranks.e2e-spec.ts
+++ b/test/users/get-ranks.e2e-spec.ts
@@ -1,0 +1,167 @@
+import { execSync } from 'child_process';
+import { INestApplication } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { PrismaClient } from '@prisma/client';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { GenericContainer, StartedTestContainer } from 'testcontainers';
+
+import { AppModule } from '@/app.module';
+import { AuthService } from '@/auth/application/auth.service';
+import { ApiResponseDto } from '@/common/dto/api-response.dto';
+import { ResponseInterceptor } from '@/common/interceptors/response.interceptor';
+import { ExceptionResponse } from '@/common/interfaces/exception-response.interface';
+import { GetRanksResponseDto, RankItemDto } from '@/users/presentation/dto/get-ranks.dto';
+
+import { seedCategories } from '../../prisma/seeds/category.seed';
+import { seedSubCategories } from '../../prisma/seeds/subcategory.seed';
+import { seedTiers } from '../../prisma/seeds/tier.seed';
+import { seedUsersAndSessions } from '../../prisma/seeds/user-session.seed';
+
+describe('GET /api/users/ranks (e2e)', () => {
+  let app: INestApplication<App>;
+  let container: StartedTestContainer;
+  let accessToken: string;
+
+  // user-session.seed.ts 기준 시드 데이터 수
+  // Master: ranker 130명 + Jin Park 1명 = 131명
+  // Gold: newbie 50명
+  const TOTAL_USERS = 181;
+  const MASTER_USERS = 131;
+  const DEFAULT_SIZE = 20;
+
+  beforeAll(async () => {
+    container = await new GenericContainer('postgres:18-alpine')
+      .withExposedPorts(5432)
+      .withEnvironment({
+        POSTGRES_USER: 'test',
+        POSTGRES_PASSWORD: 'test',
+        POSTGRES_DB: 'test',
+      })
+      .start();
+
+    const databaseUrl = `postgresql://test:test@${container.getHost()}:${container.getMappedPort(5432)}/test`;
+    process.env.DATABASE_URL = databaseUrl;
+
+    execSync('npx prisma migrate deploy', {
+      env: { ...process.env, DATABASE_URL: databaseUrl },
+    });
+
+    const prisma = new PrismaClient({ datasourceUrl: databaseUrl });
+
+    await seedTiers(prisma);
+    await seedCategories(prisma);
+    await seedSubCategories(prisma);
+    await seedUsersAndSessions(prisma);
+
+    const testUser = await prisma.user.findUnique({ where: { email: 'jinpark@example.com' } });
+    await prisma.$disconnect();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.useGlobalInterceptors(new ResponseInterceptor(app.get(Reflector)));
+    await app.init();
+
+    const authService = moduleFixture.get(AuthService);
+    accessToken = authService.createAccessToken(testUser!.id);
+  }, 60000);
+
+  afterAll(async () => {
+    await app?.close();
+    await container?.stop();
+  });
+
+  it('scope=tier 일 때, 비회원일 경우 403 에러를 응답한다.', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/api/users/ranks?scope=tier')
+      .expect(403);
+
+    const body = response.body as ApiResponseDto & ExceptionResponse;
+
+    expect(body.success).toBe(false);
+    expect(body.message).toBe('티어 랭킹 조회는 회원만 가능합니다.');
+  });
+
+  it('scope 없이 요청 시 전체 랭킹을 조회한다.', async () => {
+    const response = await request(app.getHttpServer()).get('/api/users/ranks').expect(200);
+
+    const body = response.body as ApiResponseDto & { data: GetRanksResponseDto };
+
+    expect(body.success).toBe(true);
+    expect(body.data.ranks).toHaveLength(DEFAULT_SIZE);
+    expect(body.data.metadata).toMatchObject({
+      page: 1,
+      size: DEFAULT_SIZE,
+      totalItems: TOTAL_USERS,
+      totalPage: Math.ceil(TOTAL_USERS / DEFAULT_SIZE),
+    });
+
+    expect(body.data.ranks[0].ranking).toBe(1);
+
+    const scores = body.data.ranks.map((r: RankItemDto) => Number(r.totalScore));
+    expect(scores).toEqual([...scores].sort((a, b) => b - a));
+  });
+
+  it('page, size 파라미터로 페이지네이션이 정상 동작한다.', async () => {
+    const page = 2;
+    const size = 10;
+    const response = await request(app.getHttpServer())
+      .get(`/api/users/ranks?page=${page}&size=${size}`)
+      .expect(200);
+
+    const body = response.body as ApiResponseDto & { data: GetRanksResponseDto };
+
+    expect(body.data.ranks).toHaveLength(size);
+    expect(body.data.metadata).toMatchObject({
+      page,
+      size,
+      totalItems: TOTAL_USERS,
+      totalPage: Math.ceil(TOTAL_USERS / size),
+    });
+
+    expect(body.data.ranks[0].ranking).toBe((page - 1) * size + 1);
+  });
+
+  it('scope=tier 일 때, 회원일 경우 자신과 같은 티어의 랭킹을 조회한다.', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/api/users/ranks?scope=tier')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+
+    const body = response.body as ApiResponseDto & { data: GetRanksResponseDto };
+
+    expect(body.success).toBe(true);
+    expect(body.data.metadata.totalItems).toBe(MASTER_USERS);
+    expect(body.data.ranks).toHaveLength(DEFAULT_SIZE);
+
+    body.data.ranks.forEach((rank: RankItemDto) => {
+      expect(rank.tier?.name).toBe('Master');
+    });
+  });
+
+  it('page가 1 미만일 경우 400 에러를 응답한다.', async () => {
+    const response = await request(app.getHttpServer()).get('/api/users/ranks?page=0').expect(400);
+
+    const body = response.body as ApiResponseDto & ExceptionResponse;
+
+    expect(body.success).toBe(false);
+    expect(body.message).toBe('page의 최솟값은 1입니다.');
+  });
+
+  it('유효하지 않은 scope 값으로 요청 시 400 에러를 응답한다.', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/api/users/ranks?scope=invalid')
+      .expect(400);
+
+    const body = response.body as ApiResponseDto & ExceptionResponse;
+
+    expect(body.success).toBe(false);
+    expect(body.message).toBe('랭킹 scope는 tier, all 중 하나여야 합니다.');
+  });
+});

--- a/test/users/get-ranks.e2e-spec.ts
+++ b/test/users/get-ranks.e2e-spec.ts
@@ -4,21 +4,21 @@ import { Reflector } from '@nestjs/core';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { PrismaClient } from '@prisma/client';
+import { AuthService } from '@auth/application/auth.service';
 import * as request from 'supertest';
 import { App } from 'supertest/types';
 import { GenericContainer, StartedTestContainer } from 'testcontainers';
 
-import { AppModule } from '@/app.module';
-import { AuthService } from '@/auth/application/auth.service';
-import { ApiResponseDto } from '@/common/dto/api-response.dto';
-import { ResponseInterceptor } from '@/common/interceptors/response.interceptor';
-import { ExceptionResponse } from '@/common/interfaces/exception-response.interface';
-import { GetRanksResponseDto, RankItemDto } from '@/users/presentation/dto/get-ranks.dto';
+import { ApiResponseDto } from '@common/dto/api-response.dto';
+import { ResponseInterceptor } from '@common/interceptors/response.interceptor';
+import { ExceptionResponse } from '@common/interfaces/exception-response.interface';
+import { GetRanksResponseDto, RankItemDto } from '@users/presentation/dto/get-ranks.dto';
 
 import { seedCategories } from '../../prisma/seeds/category.seed';
 import { seedSubCategories } from '../../prisma/seeds/subcategory.seed';
 import { seedTiers } from '../../prisma/seeds/tier.seed';
 import { seedUsersAndSessions } from '../../prisma/seeds/user-session.seed';
+import { AppModule } from '../../src/app.module';
 
 describe('GET /api/users/ranks (e2e)', () => {
   let app: INestApplication<App>;


### PR DESCRIPTION
# 백엔드 PR

## 📋 변경 사항 요약
랭킹 전체 조회 시 `tierId`를 받아 필터링하는 로직에서 `scope=tier`일 경우 인증된 유저 정보로 자동 필터링 하도록 수정했습니다.
tier 정보를 클라이언트에서 보낼 수도 있으나 점수에 따라 변동성이 있는 필드라 티어 필터링이 필요할 경우 서버에서 티어를 조회해 필터링 하도록 수정합니다.
<!-- PR의 목적을 간략히 설명 -->

## 🔗 관련 Issue

Closes #40 

## 🎯 변경 내용

- [ ] ranks 조회 query dto 수정
   - `tierId` 삭제
   - `scope` 추가 (`all` / `tier`로 필터링 범위를 의미, 보내지 않을 경우 default = all 로 동작)
- [ ] ranks 조회 서비스 로직 수정
   - `scope = tier` 일 경우 회원 인증을 통해 얻은 `userId`로 티어를 조회해 필터링하도록 수정
   - 비회원이 tier 범위로 요청 시 403 에러 반환
- [ ] 테스트 코드 수정 및 e2e 테스트 추가

## 📌 추가 참고사항
<img width="519" height="449" alt="image" src="https://github.com/user-attachments/assets/f9786a45-10bb-4f5e-b4e2-754f62a3821c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a scope-based ranking filter to view either all users or tier-specific rankings.

* **Improvements**
  * Tier-scoped rankings now require authentication and correctly filter results when authorized.
  * Validation messages for pagination and scope inputs are clearer and localized.

* **Tests**
  * Added comprehensive end-to-end and unit tests covering scope behavior, access control, validation, and pagination.

* **Documentation**
  * Swagger responses for error cases consolidated into standardized helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->