### PR TITLE
[게임] 게임세션 저장이후 유저의 티어등급 변경 반영 & user.totalScore 증분방법으로 변경

### DIFF
--- a/src/games/application/game-session.service.spec.ts
+++ b/src/games/application/game-session.service.spec.ts
@@ -35,6 +35,34 @@ describe('GameSessionService', () => {
     >
   >;
 
+  const createMockProblem = (id: number, difficulty: ProblemDifficulty = 'Easy'): GameProblem =>
+    GameProblem.from({
+      id: BigInt(id),
+      title: `문제 ${id}`,
+      subCategoryName: 'Test',
+      text: `문제 ${id}`,
+      answer: `answer`,
+      point: DIFFICULTY_SCORES[difficulty],
+      difficulty,
+    });
+
+  const createClientAnswers = (
+    overrides: Record<number, Partial<ClientAnswer>> = {},
+  ): ClientAnswer[] =>
+    Array.from({ length: MAX_PROBLEMS_PER_GAME }, (_, i) => ({
+      problemId: String(i + 1),
+      inputs: [],
+      solved: false,
+      ...overrides[i],
+    }));
+
+  const mockProblems: GameProblem[] = [
+    createMockProblem(1, 'Easy'),
+    createMockProblem(2, 'Normal'),
+    createMockProblem(3, 'Hard'),
+    ...Array.from({ length: 17 }, (_, i) => createMockProblem(i + 4, 'Easy')),
+  ];
+
   beforeEach(async () => {
     const mockGameRepository = {
       getSessionHistoryByFilter: jest.fn(),
@@ -85,39 +113,118 @@ describe('GameSessionService', () => {
       expect(gameRepository.getSessionHistoryByFilter).toHaveBeenCalledWith(filter);
     });
   });
-  describe('createGameSession', () => {
-    const createMockProblem = (id: number, difficulty: ProblemDifficulty = 'Easy'): GameProblem =>
-      GameProblem.from({
-        id: BigInt(id),
-        title: `문제 ${id}`,
-        subCategoryName: 'Test',
-        text: `문제 ${id}`,
-        answer: `answer`,
-        point: DIFFICULTY_SCORES[difficulty],
-        difficulty,
-      });
 
-    const createClientAnswers = (
-      overrides: Record<number, Partial<ClientAnswer>> = {},
-    ): ClientAnswer[] =>
-      Array.from({ length: MAX_PROBLEMS_PER_GAME }, (_, i) => ({
-        problemId: String(i + 1),
-        inputs: [],
-        solved: false,
-        ...overrides[i],
-      }));
-
-    const mockProblems: GameProblem[] = [
-      createMockProblem(1, 'Easy'),
-      createMockProblem(2, 'Normal'),
-      createMockProblem(3, 'Hard'),
-      ...Array.from({ length: 17 }, (_, i) => createMockProblem(i + 4, 'Easy')),
-    ];
-
+  describe('validateAndCalculateScore', () => {
     describe('✅ 성공 케이스', () => {
-      it('게임 세션을 정상적으로 저장하고 gameSessionId를 반환한다.', async () => {
+      it('클라이언트 답안을 검증하고 서버 점수를 계산하여 반환한다.', async () => {
         gameRepository.categoryExists.mockResolvedValue(true);
         gameRepository.findProblemsByIds.mockResolvedValue(mockProblems);
+
+        const clientAnswers = createClientAnswers({
+          0: { inputs: [{ input: 'git init', isCorrect: true }], solved: true },
+          1: {
+            inputs: [
+              { input: 'git add', isCorrect: false },
+              { input: 'git commit', isCorrect: true },
+            ],
+            solved: true,
+          },
+          2: { inputs: [{ input: 'git merge', isCorrect: false }], solved: false },
+        });
+
+        const result = await service.validateAndCalculateScore(1, clientAnswers);
+
+        // Easy(10) + Normal(30) = 40 (Hard는 미해결)
+        expect(result).toBe(40);
+      });
+
+      it('모든 문제를 틀리면 0점을 반환한다.', async () => {
+        gameRepository.categoryExists.mockResolvedValue(true);
+        gameRepository.findProblemsByIds.mockResolvedValue(mockProblems);
+
+        const clientAnswers = createClientAnswers();
+
+        const result = await service.validateAndCalculateScore(1, clientAnswers);
+
+        expect(result).toBe(0);
+      });
+    });
+
+    describe('❌ 실패 케이스', () => {
+      it('존재하지 않는 카테고리면 NotFoundException을 던진다.', async () => {
+        gameRepository.categoryExists.mockResolvedValue(false);
+
+        await expect(service.validateAndCalculateScore(999, createClientAnswers())).rejects.toThrow(
+          NotFoundException,
+        );
+      });
+
+      it('clientAnswers에 중복된 problemId가 포함되어 있으면 BadRequestException을 던진다.', async () => {
+        gameRepository.categoryExists.mockResolvedValue(true);
+
+        // problemId "1"을 2번 사용하여 중복 발생 (총 20개는 유지)
+        const clientAnswers = createClientAnswers({
+          19: {
+            problemId: '1',
+            inputs: [{ input: 'git init', isCorrect: true }],
+            solved: true,
+          },
+        });
+
+        await expect(service.validateAndCalculateScore(1, clientAnswers)).rejects.toThrow(
+          BadRequestException,
+        );
+
+        expect(gameRepository.findProblemsByIds).not.toHaveBeenCalled();
+      });
+
+      it('존재하지 않는 문제가 포함되어 있으면 NotFoundException을 던진다.', async () => {
+        gameRepository.categoryExists.mockResolvedValue(true);
+        // 20개 요청했는데 19개만 조회됨 (problemId=3 누락)
+        const problemsWithout3 = mockProblems.filter((p) => p.id !== BigInt(3));
+        gameRepository.findProblemsByIds.mockResolvedValue(problemsWithout3);
+
+        const clientAnswers = createClientAnswers();
+
+        await expect(service.validateAndCalculateScore(1, clientAnswers)).rejects.toThrow(
+          NotFoundException,
+        );
+      });
+
+      it('solved=true인데 정답 입력이 없으면 BadRequestException을 던진다.', async () => {
+        const clientAnswers = createClientAnswers({
+          0: {
+            inputs: [{ input: 'wrong', isCorrect: false }],
+            solved: true,
+          },
+        });
+
+        await expect(service.validateAndCalculateScore(1, clientAnswers)).rejects.toThrow(
+          BadRequestException,
+        );
+
+        expect(gameRepository.categoryExists).not.toHaveBeenCalled();
+        expect(gameRepository.findProblemsByIds).not.toHaveBeenCalled();
+      });
+
+      it('solved=true이고 inputs가 빈 배열이면 BadRequestException을 던진다.', async () => {
+        const clientAnswers = createClientAnswers({
+          0: { inputs: [], solved: true },
+        });
+
+        await expect(service.validateAndCalculateScore(1, clientAnswers)).rejects.toThrow(
+          BadRequestException,
+        );
+
+        expect(gameRepository.categoryExists).not.toHaveBeenCalled();
+        expect(gameRepository.findProblemsByIds).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('createGameSession', () => {
+    describe('✅ 성공 케이스', () => {
+      it('게임 세션을 정상적으로 저장하고 gameSessionId를 반환한다.', async () => {
         gameRepository.saveGameSession.mockResolvedValue(BigInt(100));
 
         const clientAnswers = createClientAnswers({
@@ -135,12 +242,11 @@ describe('GameSessionService', () => {
         const result = await service.createGameSession({
           categoryId: 1,
           difficultyMode: GameDifficultyMode.Normal,
-          score: 999,
+          score: 40,
           clientAnswers,
         });
 
         expect(result).toBe(BigInt(100));
-        // Easy(10) + Normal(30) = 40 (Hard는 미해결)
         expect(gameRepository.saveGameSession).toHaveBeenCalledWith(
           expect.objectContaining({
             score: 40,
@@ -151,8 +257,6 @@ describe('GameSessionService', () => {
       });
 
       it('모든 문제를 틀려도 gameSessionId를 정상 반환한다.', async () => {
-        gameRepository.categoryExists.mockResolvedValue(true);
-        gameRepository.findProblemsByIds.mockResolvedValue(mockProblems);
         gameRepository.saveGameSession.mockResolvedValue(BigInt(101));
 
         const clientAnswers = createClientAnswers();
@@ -175,8 +279,6 @@ describe('GameSessionService', () => {
       });
 
       it('userId가 전달되면 userId를 포함한 게임 세션을 저장한다.', async () => {
-        gameRepository.categoryExists.mockResolvedValue(true);
-        gameRepository.findProblemsByIds.mockResolvedValue(mockProblems);
         gameRepository.saveGameSession.mockResolvedValue(BigInt(102));
 
         const clientAnswers = createClientAnswers({
@@ -196,133 +298,6 @@ describe('GameSessionService', () => {
         expect(gameRepository.saveGameSession).toHaveBeenCalledWith(
           expect.objectContaining({ userId: 99n }),
         );
-      });
-
-      it('실제로는 0점인데 클라이언트가 999점으로 점수조작하더라도, 0점으로 계산됨을 성공한다', async () => {
-        gameRepository.categoryExists.mockResolvedValue(true);
-        gameRepository.findProblemsByIds.mockResolvedValue(mockProblems);
-        gameRepository.saveGameSession.mockResolvedValue(BigInt(103));
-
-        const clientAnswers = createClientAnswers({
-          0: { inputs: [{ input: 'wrong', isCorrect: false }], solved: false },
-        });
-
-        const result = await service.createGameSession({
-          categoryId: 1,
-          difficultyMode: GameDifficultyMode.Easy,
-          score: 999,
-          clientAnswers,
-        });
-
-        expect(result).toBe(BigInt(103));
-        expect(gameRepository.saveGameSession).toHaveBeenCalledWith(
-          expect.objectContaining({ score: 0, correctProblemCount: 0 }),
-        );
-      });
-    });
-
-    describe('❌ 실패 케이스', () => {
-      it('존재하지 않는 카테고리면 NotFoundException을 던진다.', async () => {
-        gameRepository.categoryExists.mockResolvedValue(false);
-
-        await expect(
-          service.createGameSession({
-            categoryId: 999,
-            difficultyMode: GameDifficultyMode.Easy,
-            score: 0,
-            clientAnswers: createClientAnswers(),
-          }),
-        ).rejects.toThrow(NotFoundException);
-
-        expect(gameRepository.saveGameSession).not.toHaveBeenCalled();
-      });
-
-      it('clientAnswers에 중복된 problemId가 포함되어 있으면 BadRequestException을 던진다.', async () => {
-        gameRepository.categoryExists.mockResolvedValue(true);
-
-        // problemId "1"을 2번 사용하여 중복 발생 (총 20개는 유지)
-        const clientAnswers = createClientAnswers({
-          19: {
-            problemId: '1',
-            inputs: [{ input: 'git init', isCorrect: true }],
-            solved: true,
-          },
-        });
-
-        await expect(
-          service.createGameSession({
-            categoryId: 1,
-            difficultyMode: GameDifficultyMode.Easy,
-            score: 0,
-            clientAnswers,
-          }),
-        ).rejects.toThrow(BadRequestException);
-
-        expect(gameRepository.findProblemsByIds).not.toHaveBeenCalled();
-        expect(gameRepository.saveGameSession).not.toHaveBeenCalled();
-      });
-
-      it('존재하지 않는 문제가 포함되어 있으면 NotFoundException을 던진다.', async () => {
-        gameRepository.categoryExists.mockResolvedValue(true);
-        // 20개 요청했는데 19개만 조회됨 (problemId=3 누락)
-        const problemsWithout3 = mockProblems.filter((p) => p.id !== BigInt(3));
-        gameRepository.findProblemsByIds.mockResolvedValue(problemsWithout3);
-
-        const clientAnswers = createClientAnswers();
-
-        await expect(
-          service.createGameSession({
-            categoryId: 1,
-            difficultyMode: GameDifficultyMode.Normal,
-            score: 0,
-            clientAnswers,
-          }),
-        ).rejects.toThrow(NotFoundException);
-
-        expect(gameRepository.saveGameSession).not.toHaveBeenCalled();
-      });
-
-      it('solved=true인데 정답 입력이 없으면 BadRequestException을 던진다.', async () => {
-        gameRepository.categoryExists.mockResolvedValue(true);
-        gameRepository.findProblemsByIds.mockResolvedValue(mockProblems);
-
-        const clientAnswers = createClientAnswers({
-          0: {
-            inputs: [{ input: 'wrong', isCorrect: false }],
-            solved: true,
-          },
-        });
-
-        await expect(
-          service.createGameSession({
-            categoryId: 1,
-            difficultyMode: GameDifficultyMode.Easy,
-            score: 0,
-            clientAnswers,
-          }),
-        ).rejects.toThrow(BadRequestException);
-
-        expect(gameRepository.saveGameSession).not.toHaveBeenCalled();
-      });
-
-      it('solved=true이고 inputs가 빈 배열이면 BadRequestException을 던진다.', async () => {
-        gameRepository.categoryExists.mockResolvedValue(true);
-        gameRepository.findProblemsByIds.mockResolvedValue(mockProblems);
-
-        const clientAnswers = createClientAnswers({
-          0: { inputs: [], solved: true },
-        });
-
-        await expect(
-          service.createGameSession({
-            categoryId: 1,
-            difficultyMode: GameDifficultyMode.Easy,
-            score: 0,
-            clientAnswers,
-          }),
-        ).rejects.toThrow(BadRequestException);
-
-        expect(gameRepository.saveGameSession).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/games/application/game-session.service.ts
+++ b/src/games/application/game-session.service.ts
@@ -59,21 +59,16 @@ export class GameSessionService {
   /*
    * @description 게임세션 저장
    */
-  async createGameSession(command: CreateGameSessionServiceRequestDto): Promise<bigint> {
-    const serverScore = await this.validateAndCalculateScore(
-      command.categoryId,
-      command.clientAnswers,
-    );
-
+  async createGameSession(serviceDto: CreateGameSessionServiceRequestDto): Promise<bigint> {
     return this.gameRepository.saveGameSession(
       SaveGameSessionEntity.from({
-        categoryId: command.categoryId,
-        difficultyMode: command.difficultyMode,
-        score: serverScore,
-        userId: command.userId,
-        totalProblemCount: command.clientAnswers.length,
-        correctProblemCount: command.clientAnswers.filter((a) => a.solved).length,
-        logs: command.clientAnswers.map((a) =>
+        categoryId: serviceDto.categoryId,
+        difficultyMode: serviceDto.difficultyMode,
+        score: serviceDto.score,
+        userId: serviceDto.userId,
+        totalProblemCount: serviceDto.clientAnswers.length,
+        correctProblemCount: serviceDto.clientAnswers.filter((a) => a.solved).length,
+        logs: serviceDto.clientAnswers.map((a) =>
           SaveGameSessionLog.from({
             problemId: BigInt(a.problemId),
             inputs: a.inputs,
@@ -83,13 +78,6 @@ export class GameSessionService {
         ),
       }),
     );
-  }
-
-  /*
-   * @description userId에 해당하는 모든 게임 세션 점수의 합계 조회
-   */
-  async getTotalScoreByUserId(userId: bigint): Promise<bigint> {
-    return await this.gameRepository.getTotalScoreByUserId(userId);
   }
 
   /*
@@ -106,7 +94,7 @@ export class GameSessionService {
   /**
    * @description 클라이언트 게임 데이터 검증 후 서버 점수 계산
    */
-  private async validateAndCalculateScore(
+  async validateAndCalculateScore(
     categoryId: number,
     clientAnswers: ClientAnswer[],
   ): Promise<number> {

--- a/src/games/application/game.facade.spec.ts
+++ b/src/games/application/game.facade.spec.ts
@@ -1,6 +1,8 @@
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { TiersService } from '@tiers/application/tiers.service';
+import { Tier } from '@tiers/domain/tiers.entity';
 import { UsersService } from '@users/application/users.service';
 
 import { GameDifficultyMode } from '../domain/game.business-rules';
@@ -18,7 +20,10 @@ describe('GameFacade', () => {
   let gameSessionService: jest.Mocked<
     Pick<GameSessionService, 'createGameSession' | 'validateAndCalculateScore'>
   >;
-  let usersService: jest.Mocked<Pick<UsersService, 'incrementTotalScore'>>;
+  let usersService: jest.Mocked<
+    Pick<UsersService, 'incrementTotalScore' | 'updateTierId' | 'findById'>
+  >;
+  let tiersService: jest.Mocked<Pick<TiersService, 'findTierByUserTotalScore'>>;
 
   beforeEach(async () => {
     const mockGamesService = {};
@@ -30,6 +35,12 @@ describe('GameFacade', () => {
 
     const mockUsersService = {
       incrementTotalScore: jest.fn(),
+      updateTierId: jest.fn(),
+      findById: jest.fn(),
+    };
+
+    const mockTiersService = {
+      findTierByUserTotalScore: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -38,12 +49,14 @@ describe('GameFacade', () => {
         { provide: GamesService, useValue: mockGamesService },
         { provide: GameSessionService, useValue: mockGameSessionService },
         { provide: UsersService, useValue: mockUsersService },
+        { provide: TiersService, useValue: mockTiersService },
       ],
     }).compile();
 
     facade = module.get<GameFacade>(GameFacade);
     gameSessionService = module.get(GameSessionService);
     usersService = module.get(UsersService);
+    tiersService = module.get(TiersService);
   });
 
   describe('saveGameSession', () => {
@@ -55,15 +68,25 @@ describe('GameFacade', () => {
     };
 
     describe('✅ 성공 케이스', () => {
-      it('회원인 경우 게임 세션 저장 후 totalScore를 증분 갱신하고 gameSessionId와 totalScore를 반환한다.', async () => {
+      it('회원인 경우 기존 티어와 다르면 티어를 승급시킨다.', async () => {
         const userId = 1n;
         const gameSessionId = 100n;
         const serverScore = 10;
         const updatedTotalScore = 150n;
+        const currentTierId = 1;
+        const newTier = Tier.from({
+          id: 2,
+          name: 'silver',
+          minScore: 100,
+          imageUrl: null,
+          iconUrl: null,
+        });
 
         gameSessionService.validateAndCalculateScore.mockResolvedValue(serverScore);
         gameSessionService.createGameSession.mockResolvedValue(gameSessionId);
         usersService.incrementTotalScore.mockResolvedValue(updatedTotalScore);
+        tiersService.findTierByUserTotalScore.mockResolvedValue(newTier);
+        usersService.findById.mockResolvedValue({ tierId: currentTierId } as any);
 
         const result = await facade.saveGameSession({ ...baseDto, userId });
 
@@ -78,9 +101,41 @@ describe('GameFacade', () => {
           expect.objectContaining({ userId, score: serverScore }),
         );
         expect(usersService.incrementTotalScore).toHaveBeenCalledWith(userId, BigInt(serverScore));
+        expect(tiersService.findTierByUserTotalScore).toHaveBeenCalledWith(updatedTotalScore);
+        expect(usersService.findById).toHaveBeenCalledWith(userId);
+        expect(usersService.updateTierId).toHaveBeenCalledWith(userId, newTier.id);
       });
 
-      it('비회원인 경우 게임 세션만 저장하고 totalScore 관련 로직을 수행하지 않으며 totalScore는 undefined로 반환한다.', async () => {
+      it('회원인 경우 기존 티어와 동일하면 updateTierId를 호출하지 않는다.', async () => {
+        const userId = 1n;
+        const gameSessionId = 100n;
+        const serverScore = 10;
+        const updatedTotalScore = 150n;
+        const sameTier = Tier.from({
+          id: 2,
+          name: 'silver',
+          minScore: 100,
+          imageUrl: null,
+          iconUrl: null,
+        });
+
+        gameSessionService.validateAndCalculateScore.mockResolvedValue(serverScore);
+        gameSessionService.createGameSession.mockResolvedValue(gameSessionId);
+        usersService.incrementTotalScore.mockResolvedValue(updatedTotalScore);
+        tiersService.findTierByUserTotalScore.mockResolvedValue(sameTier);
+        usersService.findById.mockResolvedValue({ tierId: sameTier.id } as any);
+
+        const result = await facade.saveGameSession({ ...baseDto, userId });
+
+        expect(result.gameSessionId).toBe(gameSessionId);
+        expect(result.totalScore).toBe(updatedTotalScore);
+
+        expect(tiersService.findTierByUserTotalScore).toHaveBeenCalledWith(updatedTotalScore);
+        expect(usersService.findById).toHaveBeenCalledWith(userId);
+        expect(usersService.updateTierId).not.toHaveBeenCalled();
+      });
+
+      it('비회원인 경우 게임 세션만 저장하고 totalScore 및 티어 관련 로직을 수행하지 않는다.', async () => {
         const gameSessionId = 200n;
         const serverScore = 10;
 
@@ -93,6 +148,8 @@ describe('GameFacade', () => {
         expect(result.totalScore).toBeUndefined();
 
         expect(usersService.incrementTotalScore).not.toHaveBeenCalled();
+        expect(tiersService.findTierByUserTotalScore).not.toHaveBeenCalled();
+        expect(usersService.updateTierId).not.toHaveBeenCalled();
       });
     });
 
@@ -121,6 +178,30 @@ describe('GameFacade', () => {
         );
 
         expect(usersService.incrementTotalScore).not.toHaveBeenCalled();
+      });
+
+      it('findTierByUserTotalScore에서 NotFoundException이 발생하면 이전 게임 세션 저장과 점수 증분도 롤백된다.', async () => {
+        const serverScore = 10;
+        const updatedTotalScore = 150n;
+
+        gameSessionService.validateAndCalculateScore.mockResolvedValue(serverScore);
+        gameSessionService.createGameSession.mockResolvedValue(100n);
+        usersService.incrementTotalScore.mockResolvedValue(updatedTotalScore);
+        tiersService.findTierByUserTotalScore.mockRejectedValue(
+          new NotFoundException('티어 정보를 찾을 수 없습니다.'),
+        );
+
+        await expect(facade.saveGameSession({ ...baseDto, userId })).rejects.toThrow(
+          NotFoundException,
+        );
+
+        // @Transactional에 의해 트랜잭션 전체가 롤백된다
+        // → createGameSession으로 저장된 게임 세션도 롤백
+        // → incrementTotalScore로 증분된 totalScore도 롤백
+        expect(gameSessionService.createGameSession).toHaveBeenCalled();
+        expect(usersService.incrementTotalScore).toHaveBeenCalledWith(userId, BigInt(serverScore));
+        expect(tiersService.findTierByUserTotalScore).toHaveBeenCalledWith(updatedTotalScore);
+        expect(usersService.updateTierId).not.toHaveBeenCalled();
       });
 
       it('incrementTotalScore 실패 시 에러가 전파되어 게임 세션 저장도 롤백되고, user의 totalScore는 변경되지 않는다.', async () => {

--- a/src/games/application/game.facade.spec.ts
+++ b/src/games/application/game.facade.spec.ts
@@ -4,6 +4,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { TiersService } from '@tiers/application/tiers.service';
 import { Tier } from '@tiers/domain/tiers.entity';
 import { UsersService } from '@users/application/users.service';
+import { IncrementTotalScoreMapper } from '@users/domain/increment-total-score.mapper';
 
 import { GameDifficultyMode } from '../domain/game.business-rules';
 import { GameSessionService } from './game-session.service';
@@ -20,9 +21,7 @@ describe('GameFacade', () => {
   let gameSessionService: jest.Mocked<
     Pick<GameSessionService, 'createGameSession' | 'validateAndCalculateScore'>
   >;
-  let usersService: jest.Mocked<
-    Pick<UsersService, 'incrementTotalScore' | 'updateTierId' | 'findById'>
-  >;
+  let usersService: jest.Mocked<Pick<UsersService, 'incrementTotalScore' | 'updateTierId'>>;
   let tiersService: jest.Mocked<Pick<TiersService, 'findTierByUserTotalScore'>>;
 
   beforeEach(async () => {
@@ -36,7 +35,6 @@ describe('GameFacade', () => {
     const mockUsersService = {
       incrementTotalScore: jest.fn(),
       updateTierId: jest.fn(),
-      findById: jest.fn(),
     };
 
     const mockTiersService = {
@@ -84,9 +82,10 @@ describe('GameFacade', () => {
 
         gameSessionService.validateAndCalculateScore.mockResolvedValue(serverScore);
         gameSessionService.createGameSession.mockResolvedValue(gameSessionId);
-        usersService.incrementTotalScore.mockResolvedValue(updatedTotalScore);
+        usersService.incrementTotalScore.mockResolvedValue(
+          IncrementTotalScoreMapper.from({ totalScore: updatedTotalScore, tierId: currentTierId }),
+        );
         tiersService.findTierByUserTotalScore.mockResolvedValue(newTier);
-        usersService.findById.mockResolvedValue({ tierId: currentTierId } as any);
 
         const result = await facade.saveGameSession({ ...baseDto, userId });
 
@@ -102,7 +101,6 @@ describe('GameFacade', () => {
         );
         expect(usersService.incrementTotalScore).toHaveBeenCalledWith(userId, BigInt(serverScore));
         expect(tiersService.findTierByUserTotalScore).toHaveBeenCalledWith(updatedTotalScore);
-        expect(usersService.findById).toHaveBeenCalledWith(userId);
         expect(usersService.updateTierId).toHaveBeenCalledWith(userId, newTier.id);
       });
 
@@ -121,9 +119,10 @@ describe('GameFacade', () => {
 
         gameSessionService.validateAndCalculateScore.mockResolvedValue(serverScore);
         gameSessionService.createGameSession.mockResolvedValue(gameSessionId);
-        usersService.incrementTotalScore.mockResolvedValue(updatedTotalScore);
+        usersService.incrementTotalScore.mockResolvedValue(
+          IncrementTotalScoreMapper.from({ totalScore: updatedTotalScore, tierId: sameTier.id }),
+        );
         tiersService.findTierByUserTotalScore.mockResolvedValue(sameTier);
-        usersService.findById.mockResolvedValue({ tierId: sameTier.id } as any);
 
         const result = await facade.saveGameSession({ ...baseDto, userId });
 
@@ -131,7 +130,6 @@ describe('GameFacade', () => {
         expect(result.totalScore).toBe(updatedTotalScore);
 
         expect(tiersService.findTierByUserTotalScore).toHaveBeenCalledWith(updatedTotalScore);
-        expect(usersService.findById).toHaveBeenCalledWith(userId);
         expect(usersService.updateTierId).not.toHaveBeenCalled();
       });
 
@@ -186,7 +184,9 @@ describe('GameFacade', () => {
 
         gameSessionService.validateAndCalculateScore.mockResolvedValue(serverScore);
         gameSessionService.createGameSession.mockResolvedValue(100n);
-        usersService.incrementTotalScore.mockResolvedValue(updatedTotalScore);
+        usersService.incrementTotalScore.mockResolvedValue(
+          IncrementTotalScoreMapper.from({ totalScore: updatedTotalScore, tierId: 1 }),
+        );
         tiersService.findTierByUserTotalScore.mockRejectedValue(
           new NotFoundException('티어 정보를 찾을 수 없습니다.'),
         );

--- a/src/games/application/game.facade.spec.ts
+++ b/src/games/application/game.facade.spec.ts
@@ -1,3 +1,4 @@
+import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { UsersService } from '@users/application/users.service';
@@ -15,20 +16,20 @@ jest.mock('@nestjs-cls/transactional', () => ({
 describe('GameFacade', () => {
   let facade: GameFacade;
   let gameSessionService: jest.Mocked<
-    Pick<GameSessionService, 'createGameSession' | 'getTotalScoreByUserId'>
+    Pick<GameSessionService, 'createGameSession' | 'validateAndCalculateScore'>
   >;
-  let usersService: jest.Mocked<Pick<UsersService, 'updateTotalScore'>>;
+  let usersService: jest.Mocked<Pick<UsersService, 'incrementTotalScore'>>;
 
   beforeEach(async () => {
     const mockGamesService = {};
 
     const mockGameSessionService = {
       createGameSession: jest.fn(),
-      getTotalScoreByUserId: jest.fn(),
+      validateAndCalculateScore: jest.fn(),
     };
 
     const mockUsersService = {
-      updateTotalScore: jest.fn(),
+      incrementTotalScore: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -54,30 +55,36 @@ describe('GameFacade', () => {
     };
 
     describe('✅ 성공 케이스', () => {
-      it('회원인 경우 게임 세션 저장 후 totalScore를 갱신하고 gameSessionId와 totalScore를 반환한다.', async () => {
+      it('회원인 경우 게임 세션 저장 후 totalScore를 증분 갱신하고 gameSessionId와 totalScore를 반환한다.', async () => {
         const userId = 1n;
         const gameSessionId = 100n;
-        const totalScore = 150n;
+        const serverScore = 10;
+        const updatedTotalScore = 150n;
 
+        gameSessionService.validateAndCalculateScore.mockResolvedValue(serverScore);
         gameSessionService.createGameSession.mockResolvedValue(gameSessionId);
-        gameSessionService.getTotalScoreByUserId.mockResolvedValue(totalScore);
-        usersService.updateTotalScore.mockResolvedValue(undefined);
+        usersService.incrementTotalScore.mockResolvedValue(updatedTotalScore);
 
         const result = await facade.saveGameSession({ ...baseDto, userId });
 
         expect(result.gameSessionId).toBe(gameSessionId);
-        expect(result.totalScore).toBe(totalScore);
+        expect(result.totalScore).toBe(updatedTotalScore);
 
-        expect(gameSessionService.createGameSession).toHaveBeenCalledWith(
-          expect.objectContaining({ userId }),
+        expect(gameSessionService.validateAndCalculateScore).toHaveBeenCalledWith(
+          baseDto.categoryId,
+          baseDto.clientAnswers,
         );
-        expect(gameSessionService.getTotalScoreByUserId).toHaveBeenCalledWith(userId);
-        expect(usersService.updateTotalScore).toHaveBeenCalledWith(userId, totalScore);
+        expect(gameSessionService.createGameSession).toHaveBeenCalledWith(
+          expect.objectContaining({ userId, score: serverScore }),
+        );
+        expect(usersService.incrementTotalScore).toHaveBeenCalledWith(userId, BigInt(serverScore));
       });
 
       it('비회원인 경우 게임 세션만 저장하고 totalScore 관련 로직을 수행하지 않으며 totalScore는 undefined로 반환한다.', async () => {
         const gameSessionId = 200n;
+        const serverScore = 10;
 
+        gameSessionService.validateAndCalculateScore.mockResolvedValue(serverScore);
         gameSessionService.createGameSession.mockResolvedValue(gameSessionId);
 
         const result = await facade.saveGameSession(baseDto);
@@ -85,32 +92,43 @@ describe('GameFacade', () => {
         expect(result.gameSessionId).toBe(gameSessionId);
         expect(result.totalScore).toBeUndefined();
 
-        expect(gameSessionService.getTotalScoreByUserId).not.toHaveBeenCalled();
-        expect(usersService.updateTotalScore).not.toHaveBeenCalled();
+        expect(usersService.incrementTotalScore).not.toHaveBeenCalled();
       });
     });
 
     describe('❌ 실패 케이스 - 트랜잭션 원자성 (에러 전파로 @Transactional 롤백 유도)', () => {
       const userId = 1n;
 
+      it('validateAndCalculateScore 실패 시 게임 세션이 저장되지 않고, totalScore 갱신도 수행되지 않는다.', async () => {
+        gameSessionService.validateAndCalculateScore.mockRejectedValue(
+          new NotFoundException('존재하지 않는 카테고리입니다.'),
+        );
+
+        await expect(facade.saveGameSession({ ...baseDto, userId })).rejects.toThrow(
+          '존재하지 않는 카테고리입니다.',
+        );
+
+        expect(gameSessionService.createGameSession).not.toHaveBeenCalled();
+        expect(usersService.incrementTotalScore).not.toHaveBeenCalled();
+      });
+
       it('createGameSession 실패 시 게임 세션이 저장되지 않고, totalScore 갱신도 수행되지 않는다.', async () => {
+        gameSessionService.validateAndCalculateScore.mockResolvedValue(10);
         gameSessionService.createGameSession.mockRejectedValue(new Error('게임 세션 저장 실패'));
 
         await expect(facade.saveGameSession({ ...baseDto, userId })).rejects.toThrow(
           '게임 세션 저장 실패',
         );
 
-        // 게임 세션 저장 자체가 실패했으므로 후속 작업이 실행되지 않아야 한다
-        expect(gameSessionService.getTotalScoreByUserId).not.toHaveBeenCalled();
-        expect(usersService.updateTotalScore).not.toHaveBeenCalled();
+        expect(usersService.incrementTotalScore).not.toHaveBeenCalled();
       });
 
-      it('updateTotalScore 실패 시 에러가 전파되어 게임 세션 저장도 롤백되고, user의 totalScore는 변경되지 않는다.', async () => {
-        const previousTotalScore = 100n;
+      it('incrementTotalScore 실패 시 에러가 전파되어 게임 세션 저장도 롤백되고, user의 totalScore는 변경되지 않는다.', async () => {
+        const serverScore = 10;
 
+        gameSessionService.validateAndCalculateScore.mockResolvedValue(serverScore);
         gameSessionService.createGameSession.mockResolvedValue(100n);
-        gameSessionService.getTotalScoreByUserId.mockResolvedValue(previousTotalScore);
-        usersService.updateTotalScore.mockRejectedValue(new Error('총 점수 업데이트 실패'));
+        usersService.incrementTotalScore.mockRejectedValue(new Error('총 점수 업데이트 실패'));
 
         await expect(facade.saveGameSession({ ...baseDto, userId })).rejects.toThrow(
           '총 점수 업데이트 실패',
@@ -118,10 +136,9 @@ describe('GameFacade', () => {
 
         // 에러가 전파되어 @Transactional에 의해 트랜잭션 전체가 롤백된다
         // → createGameSession으로 저장된 게임 세션도 롤백
-        // → updateTotalScore가 실패했으므로 user.totalScore는 이전 값(previousTotalScore) 그대로 유지
+        // → incrementTotalScore가 실패했으므로 user.totalScore는 이전 값 그대로 유지
         expect(gameSessionService.createGameSession).toHaveBeenCalled();
-        expect(gameSessionService.getTotalScoreByUserId).toHaveBeenCalledWith(userId);
-        expect(usersService.updateTotalScore).toHaveBeenCalledWith(userId, previousTotalScore);
+        expect(usersService.incrementTotalScore).toHaveBeenCalledWith(userId, BigInt(serverScore));
       });
     });
   });

--- a/src/games/application/game.facade.ts
+++ b/src/games/application/game.facade.ts
@@ -62,11 +62,13 @@ export class GameFacade {
     userId: bigint,
     serverScore: number,
   ): Promise<bigint> {
-    const totalScore = await this.userService.incrementTotalScore(userId, BigInt(serverScore));
+    const { totalScore, tierId: currentTierId } = await this.userService.incrementTotalScore(
+      userId,
+      BigInt(serverScore),
+    );
 
-    const currentUser = await this.userService.findById(userId);
     const newTier = await this.tiersService.findTierByUserTotalScore(totalScore);
-    if (currentUser.tierId !== newTier.id) {
+    if (currentTierId !== newTier.id) {
       await this.userService.updateTierId(userId, newTier.id);
     }
 

--- a/src/games/application/game.facade.ts
+++ b/src/games/application/game.facade.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { Transactional } from '@nestjs-cls/transactional';
 
+import { TiersService } from '@tiers/application/tiers.service';
 import { UsersService } from '@users/application/users.service';
 
 import {
@@ -15,6 +16,7 @@ export class GameFacade {
   constructor(
     private readonly gameSessionService: GameSessionService,
     private readonly userService: UsersService,
+    private readonly tiersService: TiersService,
   ) {}
 
   /*
@@ -46,7 +48,12 @@ export class GameFacade {
         facadeDto.userId,
         BigInt(serverScore),
       );
-      // FIXME: 게임점수 저장후, 유저의 totalScore가 다음티어로 승급이 되는지 확인. (현재티어보다 한단계높은 티어의 minScore이상인지 확인)
+
+      // 티어 승급 체크 & 업데이트
+      const newTier = await this.tiersService.findTierByScore(totalScore);
+      if (newTier) {
+        await this.userService.updateTierId(facadeDto.userId, newTier.id);
+      }
     }
 
     return {

--- a/src/games/application/game.facade.ts
+++ b/src/games/application/game.facade.ts
@@ -65,7 +65,7 @@ export class GameFacade {
     const totalScore = await this.userService.incrementTotalScore(userId, BigInt(serverScore));
 
     const currentUser = await this.userService.findById(userId);
-    const newTier = await this.tiersService.findTierByScore(totalScore);
+    const newTier = await this.tiersService.findTierByUserTotalScore(totalScore);
     if (currentUser.tierId !== newTier.id) {
       await this.userService.updateTierId(userId, newTier.id);
     }

--- a/src/games/application/game.facade.ts
+++ b/src/games/application/game.facade.ts
@@ -24,18 +24,29 @@ export class GameFacade {
   async saveGameSession(
     facadeDto: SaveGameSessionFacadeRequestDto,
   ): Promise<SaveGameSessionFacadeResponseDto> {
+    // 클라이언트값의 facadeDto.score가 검증된 점수인지 확인.
+    const serverScore = await this.gameSessionService.validateAndCalculateScore(
+      facadeDto.categoryId,
+      facadeDto.clientAnswers,
+    );
+
+    // 게임세션 저장
     const gameSessionId = await this.gameSessionService.createGameSession({
       categoryId: facadeDto.categoryId,
       difficultyMode: facadeDto.difficultyMode,
-      score: facadeDto.score,
+      score: serverScore,
       clientAnswers: facadeDto.clientAnswers,
       userId: facadeDto.userId,
     });
 
     let totalScore: bigint | undefined = undefined;
     if (facadeDto.userId) {
-      totalScore = await this.gameSessionService.getTotalScoreByUserId(facadeDto.userId);
-      await this.userService.updateTotalScore(facadeDto.userId, totalScore);
+      // (회원인경우) 유저의 totalScore에 서버 점수를 증분 업데이트
+      totalScore = await this.userService.incrementTotalScore(
+        facadeDto.userId,
+        BigInt(serverScore),
+      );
+      // FIXME: 게임점수 저장후, 유저의 totalScore가 다음티어로 승급이 되는지 확인. (현재티어보다 한단계높은 티어의 minScore이상인지 확인)
     }
 
     return {

--- a/src/games/application/game.facade.ts
+++ b/src/games/application/game.facade.ts
@@ -21,18 +21,21 @@ export class GameFacade {
 
   /*
    * @description 게임 세션 저장
+   *
+   * - 클라이언트의 입력데이터가 올바른 형태인지 유효성 검증하고 서버에서 게임점수를 한번더 재검증합니다. 재검증된 게임점수를 serverScore라 합니다.
+   * - 검증된 점수 serverScore 를 게임세션에 테이블에 저장합니다.
+   * - 유저의 경우에는 유저의 totalScore에  serverScore 을 누적합니다.
+   * - totalScore 업데이트로 티어등급이 유저의 현재 티어등급과 다르다면, 승급되었으므로 totalScore 기반의 티어등급으로 업데이트합니다.
    */
   @Transactional()
   async saveGameSession(
     facadeDto: SaveGameSessionFacadeRequestDto,
   ): Promise<SaveGameSessionFacadeResponseDto> {
-    // 클라이언트값의 facadeDto.score가 검증된 점수인지 확인.
     const serverScore = await this.gameSessionService.validateAndCalculateScore(
       facadeDto.categoryId,
       facadeDto.clientAnswers,
     );
 
-    // 게임세션 저장
     const gameSessionId = await this.gameSessionService.createGameSession({
       categoryId: facadeDto.categoryId,
       difficultyMode: facadeDto.difficultyMode,
@@ -43,22 +46,30 @@ export class GameFacade {
 
     let totalScore: bigint | undefined = undefined;
     if (facadeDto.userId) {
-      // (회원인경우) 유저의 totalScore에 서버 점수를 증분 업데이트
-      totalScore = await this.userService.incrementTotalScore(
-        facadeDto.userId,
-        BigInt(serverScore),
-      );
-
-      // 티어 승급 체크 & 업데이트
-      const newTier = await this.tiersService.findTierByScore(totalScore);
-      if (newTier) {
-        await this.userService.updateTierId(facadeDto.userId, newTier.id);
-      }
+      totalScore = await this.updateTotalScoreAndTierForUser(facadeDto.userId, serverScore);
     }
 
     return {
       gameSessionId,
       totalScore,
     };
+  }
+
+  /*
+   * @description (유저용) 게임결과 저장이후 유저의 totalScore와 totalScore 업데이트로 인해 유저의 티어 업데이트
+   */
+  private async updateTotalScoreAndTierForUser(
+    userId: bigint,
+    serverScore: number,
+  ): Promise<bigint> {
+    const totalScore = await this.userService.incrementTotalScore(userId, BigInt(serverScore));
+
+    const currentUser = await this.userService.findById(userId);
+    const newTier = await this.tiersService.findTierByScore(totalScore);
+    if (currentUser.tierId !== newTier.id) {
+      await this.userService.updateTierId(userId, newTier.id);
+    }
+
+    return totalScore;
   }
 }

--- a/src/games/domain/games.repository.interface.ts
+++ b/src/games/domain/games.repository.interface.ts
@@ -75,9 +75,4 @@ export interface IGameRepository {
    * @description 게임 세션에 유저 ID 업데이트
    */
   updateUserIdToGameSession(sessionId: bigint, userId: bigint): Promise<boolean>;
-
-  /**
-   * @description userId에 해당하는 모든 게임 세션 점수의 합계 조회
-   */
-  getTotalScoreByUserId(userId: bigint): Promise<bigint>;
 }

--- a/src/games/games.module.ts
+++ b/src/games/games.module.ts
@@ -3,6 +3,7 @@ import { forwardRef, Module } from '@nestjs/common';
 import { AuthModule } from '@auth/auth.module';
 
 import { PrismaModule } from '@prisma/prisma.module';
+import { TiersModule } from '@tiers/tiers.module';
 import { UsersModule } from '@users/users.module';
 
 import { GameSessionService } from './application/game-session.service';
@@ -14,7 +15,7 @@ import { GameRepositoryImpl } from './infrastructure/games.repository';
 import { GamesController } from './presentation/games.controller';
 
 @Module({
-  imports: [forwardRef(() => AuthModule), PrismaModule, forwardRef(() => UsersModule)],
+  imports: [forwardRef(() => AuthModule), PrismaModule, forwardRef(() => UsersModule), TiersModule],
   providers: [
     GameFacade,
     GamesService,

--- a/src/games/infrastructure/games.repository.ts
+++ b/src/games/infrastructure/games.repository.ts
@@ -448,19 +448,6 @@ export class GameRepositoryImpl implements IGameRepository {
     return valid.map((item) => ({ input: item.input, isCorrect: item.isCorrect }));
   }
 
-  /**
-   * @description userId에 해당하는 모든 게임 세션 점수의 합계 조회
-   * - @Transactional() 컨텍스트 내에서 호출 시 해당 트랜잭션에 참여
-   */
-  async getTotalScoreByUserId(userId: bigint): Promise<bigint> {
-    const result = await this.txHost.tx.gameSession.aggregate({
-      where: { userId },
-      _sum: { score: true },
-    });
-
-    return BigInt(result._sum.score ?? 0);
-  }
-
   /*
    * @description 게임 세션에 유저 ID 업데이트
    */

--- a/src/tiers/application/tiers.service.spec.ts
+++ b/src/tiers/application/tiers.service.spec.ts
@@ -1,10 +1,9 @@
-import { Test, TestingModule } from '@nestjs/testing';
 import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
 
-import { TiersService } from './tiers.service';
-
-import { ITiersRepository, TIER_REPOSITORY } from '../domain/tiers.repository.interface';
 import { Tier } from '../domain/tiers.entity';
+import { ITiersRepository, TIER_REPOSITORY } from '../domain/tiers.repository.interface';
+import { TiersService } from './tiers.service';
 
 describe('TiersService', () => {
   let service: TiersService;
@@ -14,6 +13,7 @@ describe('TiersService', () => {
     mockTiersRepository = {
       findAll: jest.fn(),
       findLowestTier: jest.fn(),
+      findTierByUserTotalScore: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -94,6 +94,31 @@ describe('TiersService', () => {
 
       await expect(service.getLowestTier()).rejects.toThrow(NotFoundException);
       expect(mockTiersRepository.findLowestTier).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('findTierByUserTotalScore', () => {
+    it('점수에 해당하는 티어를 반환한다.', async () => {
+      const mockTier = new Tier(
+        2,
+        'Silver',
+        100,
+        'https://example.com/silver.png',
+        'https://example.com/silver-icon.png',
+      );
+      mockTiersRepository.findTierByUserTotalScore.mockResolvedValue(mockTier);
+
+      const result = await service.findTierByUserTotalScore(150n);
+
+      expect(result).toEqual(mockTier);
+      expect(mockTiersRepository.findTierByUserTotalScore).toHaveBeenCalledWith(150n);
+    });
+
+    it('점수에 해당하는 티어가 없으면 NotFoundException 발생', async () => {
+      mockTiersRepository.findTierByUserTotalScore.mockResolvedValue(null);
+
+      await expect(service.findTierByUserTotalScore(150n)).rejects.toThrow(NotFoundException);
+      expect(mockTiersRepository.findTierByUserTotalScore).toHaveBeenCalledWith(150n);
     });
   });
 });

--- a/src/tiers/application/tiers.service.ts
+++ b/src/tiers/application/tiers.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 
-import { ITiersRepository, TIER_REPOSITORY } from '../domain/tiers.repository.interface';
 import { Tier } from '../domain/tiers.entity';
+import { ITiersRepository, TIER_REPOSITORY } from '../domain/tiers.repository.interface';
 
 @Injectable()
 export class TiersService {
@@ -24,5 +24,17 @@ export class TiersService {
     }
 
     return lowestTier;
+  }
+
+  /**
+   * @description 유저의 totalScore 점수에 해당하는 가장 높은 티어 조회
+   */
+  async findTierByUserTotalScore(score: bigint): Promise<Tier> {
+    const tier = await this.tiersRepository.findTierByUserTotalScore(score);
+    if (!tier) {
+      throw new NotFoundException('티어 정보를 찾을 수 없습니다.');
+    }
+
+    return tier;
   }
 }

--- a/src/tiers/domain/tiers.repository.interface.ts
+++ b/src/tiers/domain/tiers.repository.interface.ts
@@ -3,6 +3,7 @@ import { Tier } from './tiers.entity';
 export interface ITiersRepository {
   findAll(): Promise<Tier[]>;
   findLowestTier(): Promise<Tier | null>;
+  findTierByUserTotalScore(score: bigint): Promise<Tier | null>;
 }
 
 export const TIER_REPOSITORY = Symbol('ITiersRepository');

--- a/src/tiers/infrastructure/tiers.repository.ts
+++ b/src/tiers/infrastructure/tiers.repository.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@nestjs/common';
+
 import { PrismaService } from '@prisma/prisma.service';
 
-import { ITiersRepository } from '../domain/tiers.repository.interface';
 import { Tier } from '../domain/tiers.entity';
+import { ITiersRepository } from '../domain/tiers.repository.interface';
 
 @Injectable()
 export class TiersRepositoryImpl implements ITiersRepository {
@@ -22,6 +23,22 @@ export class TiersRepositoryImpl implements ITiersRepository {
   async findLowestTier(): Promise<Tier | null> {
     const tier = await this.prisma.tier.findFirst({
       orderBy: { minScore: 'asc' },
+    });
+
+    if (!tier) {
+      return null;
+    }
+
+    return Tier.from(tier);
+  }
+
+  /**
+   * @description 점수에 해당하는 가장 높은 티어 조회
+   */
+  async findTierByUserTotalScore(score: bigint): Promise<Tier | null> {
+    const tier = await this.prisma.tier.findFirst({
+      where: { minScore: { lte: Number(score) } },
+      orderBy: { minScore: 'desc' },
     });
 
     if (!tier) {

--- a/src/users/application/users.service.spec.ts
+++ b/src/users/application/users.service.spec.ts
@@ -66,6 +66,7 @@ describe('UsersService', () => {
       getRankingByScore: jest.fn(),
       getScoreDetailByUserId: jest.fn(),
       incrementTotalScore: jest.fn(),
+      updateTierId: jest.fn(),
     };
 
     mockGamesService = {
@@ -195,6 +196,17 @@ describe('UsersService', () => {
 
       expect(result.frequentWrongCategories[0].iconUrl).toBe('https://example.com/git.png');
       expect(result.frequentWrongCategories[1].iconUrl).toBe('https://example.com/docker.png');
+    });
+  });
+
+  describe('updateTierId', () => {
+    it('repository의 updateTierId를 호출하는지 확인', async () => {
+      const userId = 1n;
+      const tierId = 3;
+
+      await service.updateTierId(userId, tierId);
+
+      expect(mockUsersRepository.updateTierId).toHaveBeenCalledWith(userId, tierId);
     });
   });
 

--- a/src/users/application/users.service.spec.ts
+++ b/src/users/application/users.service.spec.ts
@@ -65,7 +65,7 @@ describe('UsersService', () => {
       getAverageScore: jest.fn(),
       getRankingByScore: jest.fn(),
       getScoreDetailByUserId: jest.fn(),
-      updateTotalScore: jest.fn(),
+      incrementTotalScore: jest.fn(),
     };
 
     mockGamesService = {

--- a/src/users/application/users.service.ts
+++ b/src/users/application/users.service.ts
@@ -101,6 +101,13 @@ export class UsersService {
   }
 
   /**
+   * @description 유저의 tierId 업데이트
+   */
+  async updateTierId(userId: bigint, tierId: number): Promise<void> {
+    await this.usersRepository.updateTierId(userId, tierId);
+  }
+
+  /**
    * @description 유저의 랭킹, 티어, 총 점수, 카테고리 별 누적점수를 조회
    */
   async getUserStats(userId: bigint): Promise<UserStats> {

--- a/src/users/application/users.service.ts
+++ b/src/users/application/users.service.ts
@@ -94,10 +94,10 @@ export class UsersService {
   }
 
   /**
-   * @description 유저의 totalScore 업데이트
+   * @description 유저의 totalScore 증분 업데이트
    */
-  async updateTotalScore(userId: bigint, totalScore: bigint): Promise<void> {
-    await this.usersRepository.updateTotalScore(userId, totalScore);
+  async incrementTotalScore(userId: bigint, scoreToAdd: bigint): Promise<bigint> {
+    return await this.usersRepository.incrementTotalScore(userId, scoreToAdd);
   }
 
   /**

--- a/src/users/application/users.service.ts
+++ b/src/users/application/users.service.ts
@@ -3,6 +3,7 @@ import { ForbiddenException, Inject, Injectable, NotFoundException } from '@nest
 import { GamesService } from '@games/application/games.service';
 import { UserMistakeAnalysis } from '@games/domain/user-mistake-analysis.entity';
 
+import { IncrementTotalScoreMapper } from '../domain/increment-total-score.mapper';
 import { UserStats } from '../domain/user-stats.entity';
 import { UserStatsMapper } from '../domain/user-stats.mapper';
 import { RankScope } from '../domain/user.business-rule';
@@ -96,7 +97,10 @@ export class UsersService {
   /**
    * @description 유저의 totalScore 증분 업데이트
    */
-  async incrementTotalScore(userId: bigint, scoreToAdd: bigint): Promise<bigint> {
+  async incrementTotalScore(
+    userId: bigint,
+    scoreToAdd: bigint,
+  ): Promise<IncrementTotalScoreMapper> {
     return await this.usersRepository.incrementTotalScore(userId, scoreToAdd);
   }
 

--- a/src/users/domain/increment-total-score.mapper.ts
+++ b/src/users/domain/increment-total-score.mapper.ts
@@ -1,0 +1,10 @@
+export class IncrementTotalScoreMapper {
+  private constructor(
+    public readonly totalScore: bigint,
+    public readonly tierId: number | null,
+  ) {}
+
+  static from(data: Pick<IncrementTotalScoreMapper, 'totalScore' | 'tierId'>) {
+    return new IncrementTotalScoreMapper(data.totalScore, data.tierId);
+  }
+}

--- a/src/users/domain/users.repository.interface.ts
+++ b/src/users/domain/users.repository.interface.ts
@@ -1,3 +1,4 @@
+import { IncrementTotalScoreMapper } from './increment-total-score.mapper';
 import { User } from './users.entity';
 
 export interface ScoreDetailOriginData {
@@ -26,7 +27,7 @@ export interface IUsersRepository {
   getAverageScore(): Promise<bigint>;
   getRankingByScore(totalScore: bigint): Promise<number>;
   getScoreDetailByUserId(userId: bigint): Promise<ScoreDetailOriginData[]>;
-  incrementTotalScore(userId: bigint, scoreToAdd: bigint): Promise<bigint>;
+  incrementTotalScore(userId: bigint, scoreToAdd: bigint): Promise<IncrementTotalScoreMapper>;
   updateTierId(userId: bigint, tierId: number): Promise<void>;
 }
 

--- a/src/users/domain/users.repository.interface.ts
+++ b/src/users/domain/users.repository.interface.ts
@@ -27,6 +27,7 @@ export interface IUsersRepository {
   getRankingByScore(totalScore: bigint): Promise<number>;
   getScoreDetailByUserId(userId: bigint): Promise<ScoreDetailOriginData[]>;
   incrementTotalScore(userId: bigint, scoreToAdd: bigint): Promise<bigint>;
+  updateTierId(userId: bigint, tierId: number): Promise<void>;
 }
 
 export const USER_REPOSITORY = Symbol('IUsersRepository');

--- a/src/users/domain/users.repository.interface.ts
+++ b/src/users/domain/users.repository.interface.ts
@@ -26,7 +26,7 @@ export interface IUsersRepository {
   getAverageScore(): Promise<bigint>;
   getRankingByScore(totalScore: bigint): Promise<number>;
   getScoreDetailByUserId(userId: bigint): Promise<ScoreDetailOriginData[]>;
-  updateTotalScore(userId: bigint, totalScore: bigint): Promise<void>;
+  incrementTotalScore(userId: bigint, scoreToAdd: bigint): Promise<bigint>;
 }
 
 export const USER_REPOSITORY = Symbol('IUsersRepository');

--- a/src/users/infrastructure/users.repository.ts
+++ b/src/users/infrastructure/users.repository.ts
@@ -156,13 +156,15 @@ export class UsersRepositoryImpl implements IUsersRepository {
   }
 
   /*
-   * @description 유저의 totalScore 업데이트
+   * @description 유저의 totalScore 증분 업데이트
    * - @Transactional() 컨텍스트 내에서 호출 시 해당 트랜잭션에 참여
    */
-  async updateTotalScore(userId: bigint, totalScore: bigint): Promise<void> {
-    await this.txHost.tx.user.update({
+  async incrementTotalScore(userId: bigint, scoreToAdd: bigint): Promise<bigint> {
+    const user = await this.txHost.tx.user.update({
       where: { id: userId },
-      data: { totalScore },
+      data: { totalScore: { increment: scoreToAdd } },
+      select: { totalScore: true },
     });
+    return user.totalScore;
   }
 }

--- a/src/users/infrastructure/users.repository.ts
+++ b/src/users/infrastructure/users.repository.ts
@@ -5,6 +5,7 @@ import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-pr
 
 import { PrismaService } from '@prisma/prisma.service';
 
+import { IncrementTotalScoreMapper } from '../domain/increment-total-score.mapper';
 import { User } from '../domain/users.entity';
 import { IUsersRepository, ScoreDetailOriginData } from '../domain/users.repository.interface';
 
@@ -159,13 +160,16 @@ export class UsersRepositoryImpl implements IUsersRepository {
    * @description 유저의 totalScore 증분 업데이트
    * - @Transactional() 컨텍스트 내에서 호출 시 해당 트랜잭션에 참여
    */
-  async incrementTotalScore(userId: bigint, scoreToAdd: bigint): Promise<bigint> {
+  async incrementTotalScore(
+    userId: bigint,
+    scoreToAdd: bigint,
+  ): Promise<IncrementTotalScoreMapper> {
     const user = await this.txHost.tx.user.update({
       where: { id: userId },
       data: { totalScore: { increment: scoreToAdd } },
-      select: { totalScore: true },
+      select: { totalScore: true, tierId: true },
     });
-    return user.totalScore;
+    return IncrementTotalScoreMapper.from({ totalScore: user.totalScore, tierId: user.tierId });
   }
 
   /**

--- a/src/users/infrastructure/users.repository.ts
+++ b/src/users/infrastructure/users.repository.ts
@@ -167,4 +167,15 @@ export class UsersRepositoryImpl implements IUsersRepository {
     });
     return user.totalScore;
   }
+
+  /**
+   * @description 유저의 tierId 업데이트
+   * - @Transactional() 컨텍스트 내에서 호출 시 해당 트랜잭션에 참여
+   */
+  async updateTierId(userId: bigint, tierId: number): Promise<void> {
+    await this.txHost.tx.user.update({
+      where: { id: userId },
+      data: { tierId },
+    });
+  }
 }

--- a/test/games/get-game-result-report.e2e-spec.ts
+++ b/test/games/get-game-result-report.e2e-spec.ts
@@ -14,6 +14,7 @@ import { ResponseInterceptor } from '@common/interceptors/response.interceptor';
 import { seedCategories } from '../../prisma/seeds/category.seed';
 import { seedGitProblems } from '../../prisma/seeds/seed-problems-git';
 import { seedSubCategories } from '../../prisma/seeds/subcategory.seed';
+import { seedTiers } from '../../prisma/seeds/tier.seed';
 import { AppModule } from '../../src/app.module';
 
 interface SaveSuccessResponse {
@@ -143,6 +144,7 @@ describe('GET /api/games/:gameSessionId/reports (e2e)', () => {
     });
 
     const prisma = new PrismaClient({ datasourceUrl: databaseUrl });
+    await seedTiers(prisma);
     await seedCategories(prisma);
     await seedSubCategories(prisma);
     await seedGitProblems(prisma);
@@ -178,6 +180,7 @@ describe('GET /api/games/:gameSessionId/reports (e2e)', () => {
         refreshToken: '',
         profileImage: null,
         githubUrl: null,
+        tierId: 1,
       },
     });
     await memberPrisma.$disconnect();
@@ -421,6 +424,7 @@ describe('GET /api/games/:gameSessionId/reports (e2e)', () => {
           refreshToken: '',
           profileImage: null,
           githubUrl: null,
+          tierId: 1,
         },
       });
       await prisma.$disconnect();

--- a/test/games/save-game-session.e2e-spec.ts
+++ b/test/games/save-game-session.e2e-spec.ts
@@ -294,12 +294,12 @@ describe('POST /api/games/save (e2e)', () => {
         expect(body.data.totalScore).toBe('90');
       });
 
-      it('첫 게임 플레이 후 DB의 user.totalScore가 게임 점수로 업데이트된다.', async () => {
+      it('게임 플레이 후 DB의 user.totalScore가 업데이트되지만, 티어 승급 조건에 미달하면 티어등급은 그대로 유지된다.', async () => {
         const dbUrl = `postgresql://test:test@${container.getHost()}:${container.getMappedPort(5432)}/test`;
         const prisma = new PrismaClient({ datasourceUrl: dbUrl });
 
         try {
-          // 테스트 전용 유저 생성 (초기 totalScore = 0)
+          // 테스트 전용 유저 생성 (초기 totalScore = 0, Bronze 티어)
           const user = await prisma.user.create({
             data: {
               email: 'score-update-test@example.com',
@@ -307,10 +307,99 @@ describe('POST /api/games/save (e2e)', () => {
               provider: 'google',
               providerId: 'score-update-test',
               refreshToken: 'dummy-refresh-token',
-              tierId: 1,
+              tierId: 1, // Bronze
             },
           });
           expect(user.totalScore).toBe(0n);
+          expect(user.tierId).toBe(1);
+
+          const jwtService = app.get(JwtService);
+          const token = jwtService.sign({ sub: String(user.id) });
+
+          // 맞춘 문제: ID 1(Easy=10점), ID 12(Normal=30점), ID 23(Hard=50점) → 서버 계산 점수 90점
+          // 90점은 Silver 승급 조건(5000점) 미달이므로 Bronze 유지
+          const response = await request(app.getHttpServer())
+            .post('/api/games/save')
+            .set('Authorization', `Bearer ${token}`)
+            .send({
+              categoryId: 1,
+              difficultyMode: 'Random',
+              score: 90,
+              clientAnswers: [
+                {
+                  problemId: '1',
+                  inputs: [{ input: 'git init', isCorrect: true }],
+                  solved: true,
+                },
+                {
+                  problemId: '12',
+                  inputs: [
+                    { input: 'git commit', isCorrect: false },
+                    { input: 'git commit --amend', isCorrect: true },
+                  ],
+                  solved: true,
+                },
+                {
+                  problemId: '23',
+                  inputs: [{ input: 'git rebase -i HEAD~3', isCorrect: true }],
+                  solved: true,
+                },
+                { problemId: '34', inputs: [], solved: false },
+                { problemId: '45', inputs: [], solved: false },
+                { problemId: '56', inputs: [], solved: false },
+                { problemId: '70', inputs: [], solved: false },
+                { problemId: '71', inputs: [], solved: false },
+                { problemId: '72', inputs: [], solved: false },
+                { problemId: '73', inputs: [], solved: false },
+                { problemId: '74', inputs: [], solved: false },
+                { problemId: '75', inputs: [], solved: false },
+                { problemId: '76', inputs: [], solved: false },
+                { problemId: '133', inputs: [], solved: false },
+                { problemId: '134', inputs: [], solved: false },
+                { problemId: '166', inputs: [], solved: false },
+                { problemId: '199', inputs: [], solved: false },
+                { problemId: '232', inputs: [], solved: false },
+                { problemId: '265', inputs: [], solved: false },
+                { problemId: '298', inputs: [], solved: false },
+              ],
+            })
+            .expect(201);
+
+          const body = response.body as SuccessResponse;
+          expect(body.success).toBe(true);
+          expect(body.data.totalScore).toBe('90');
+
+          // DB에서 직접 조회하여 totalScore 업데이트 및 티어 유지 확인
+          const updatedUser = await prisma.user.findUnique({
+            where: { id: user.id },
+          });
+          expect(updatedUser!.totalScore).toBe(90n);
+          expect(updatedUser!.tierId).toBe(1); // Bronze 유지
+        } finally {
+          await prisma.$disconnect();
+        }
+      });
+
+      it('게임 플레이 이후 user.totalScore 업데이트로 인해서, 게임 티어등급이 승급된다.', async () => {
+        const dbUrl = `postgresql://test:test@${container.getHost()}:${container.getMappedPort(5432)}/test`;
+        const prisma = new PrismaClient({ datasourceUrl: dbUrl });
+
+        try {
+          // Bronze → Silver 승급 테스트 (Silver minScore = 5000)
+          // 초기 totalScore = 4910, 게임 점수 90점 → 총 5000점으로 Silver 달성
+          const user = await prisma.user.create({
+            data: {
+              email: 'tier-promotion-test@example.com',
+              nickname: 'tier-promotion-tester',
+              provider: 'google',
+              providerId: 'tier-promotion-test',
+              refreshToken: 'dummy-refresh-token',
+              tierId: 1, // Bronze
+              totalScore: 4910,
+            },
+          });
+          expect(user.tierId).toBe(1);
+          expect(user.totalScore).toBe(4910n);
 
           const jwtService = app.get(JwtService);
           const token = jwtService.sign({ sub: String(user.id) });
@@ -365,13 +454,14 @@ describe('POST /api/games/save (e2e)', () => {
 
           const body = response.body as SuccessResponse;
           expect(body.success).toBe(true);
-          expect(body.data.totalScore).toBe('90');
+          expect(body.data.totalScore).toBe('5000');
 
-          // DB에서 직접 조회하여 user.totalScore가 실제로 업데이트되었는지 확인
+          // DB에서 직접 조회하여 totalScore 업데이트 및 tierId 승급 확인
           const updatedUser = await prisma.user.findUnique({
             where: { id: user.id },
           });
-          expect(updatedUser!.totalScore).toBe(90n);
+          expect(updatedUser!.totalScore).toBe(5000n);
+          expect(updatedUser!.tierId).toBe(2); // Silver로 승급
         } finally {
           await prisma.$disconnect();
         }


### PR DESCRIPTION
# 백엔드 PR

## 📋 변경 사항 요약

- 게임세션저장이후 : (유저한정) 검증 -> 저장 -> 서버검증 점수 증분으로 user.totalScore방식 업데이트
- 티어 업데이트 단계 추가: (유저한정) 검증 -> 저장 -> user.totalScore 업데이트 -> 티어업데이트

## 🔗 관련 Issue

Closes #62

## 🎯 변경 내용

- [x] 게임세션저장 facade 로직리팩터링 (참고 PR #60 코멘트)
( 데이터 검증 -> 저장 -> totalScore 증분 업데이트 )
- [x] GameFacade 의 saveGameSession에서   티어변경 (서비스 가입한 유저 한정)
현재유저의 티어와 totalScore 으로 조회한 티어를 확인한후에
티어가 서로다르면 update하는 방식으로 했습니다.

## 📌 추가 참고사항

- 게임결과리포트 e2e 테스트케이스 실패사례가 있어서 수정했습니다.
- 운영DB의 game_session, game_session_logs 테이블에서 시퀀스와 id 불일치 이슈 해결했습니다 (#63)
- JWT_AUTH_CODE_SECRET 과 JWT_TOKEN_SECRET 값이 모두 필요한지 DM으로 문의했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated tier progression system—users automatically advance to higher tiers as they accumulate points.
  * Server-side score validation ensures game session results are securely computed and stored.

* **Improvements**
  * Enhanced score tracking with automatic tier promotions based on user progression milestones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->