### PR TITLE
[게임] 비회원이 회원의 게임결과 리포트 조회되는 버그 수정

### DIFF
--- a/src/games/application/game-session.service.spec.ts
+++ b/src/games/application/game-session.service.spec.ts
@@ -341,13 +341,13 @@ describe('GameSessionService', () => {
 
     describe('회원용', () => {
       describe('✅ 성공 케이스', () => {
-        it('게임 결과 리포트를 정상적으로 반환한다.', async () => {
+        it('본인의 게임 결과 리포트를 정상적으로 반환한다.', async () => {
           const gameSessionId = 7n;
           const userId = 1n;
           const expectedReport = createMockGameResultReport(userId);
           gameRepository.findGameResultReport.mockResolvedValue(expectedReport);
 
-          const result = await service.getGameResultReport(gameSessionId);
+          const result = await service.getGameResultReport(gameSessionId, userId);
 
           expect(result).toEqual(expectedReport);
           expect(result.isGuest).toBe(false);
@@ -377,6 +377,17 @@ describe('GameSessionService', () => {
           await expect(
             service.getGameResultReport(gameSessionId, accessRequestUserId),
           ).rejects.toThrow(new ForbiddenException('해당 게임 결과 리포트에 접근할 수 없습니다.'));
+        });
+
+        it('비회원이 회원의 게임 결과 리포트에 접근하면 ForbiddenException을 던진다.', async () => {
+          const gameSessionId = 7n;
+          const reportOwnerUserId = 1n;
+          const mockReport = createMockGameResultReport(reportOwnerUserId);
+          gameRepository.findGameResultReport.mockResolvedValue(mockReport);
+
+          await expect(service.getGameResultReport(gameSessionId)).rejects.toThrow(
+            new ForbiddenException('해당 게임 결과 리포트에 접근할 수 없습니다.'),
+          );
         });
       });
     });

--- a/src/games/application/game-session.service.ts
+++ b/src/games/application/game-session.service.ts
@@ -35,8 +35,15 @@ export class GameSessionService {
 
   /*
    * @description 게임종료후 게임결과 리포트 조회
+   * (1) 응답데이터
    * - 비회원: gameSessionId만 사용, 결과데이터 일부 열람 제한
    * - 회원: gameSessionId, userId 모두 사용, 전체 열람 가능
+   *
+   * (2) 열람제어
+   * - 비회원은 다른 비회원의 게임결과 리포트를 열람할 수 있다.
+   * - 회원은 비회원의 게임결과 리포트를 열람할 수 있다.
+   * - 비회원은 회원의 게임결과 리포트를 열람할 수 없다. (403 예외 발생)
+   * - 회원은 다른회원의 게임결과 리포트를 열람할 수 없다. (403 예외 발생)
    */
   async getGameResultReport(gameSessionId: bigint, userId?: bigint): Promise<GameResultReport> {
     const gameResultReport = await this.gameRepository.findGameResultReport(gameSessionId);
@@ -49,7 +56,7 @@ export class GameSessionService {
       return gameResultReport.toGuestView(GUEST_MAX_VIEWABLE_PROBLEMS);
     }
 
-    if (userId && userId !== gameResultReport.summary.userId) {
+    if (!userId || userId !== gameResultReport.summary.userId) {
       throw new ForbiddenException('해당 게임 결과 리포트에 접근할 수 없습니다.');
     }
 

--- a/src/games/presentation/decorators/get-game-result-report-swagger.decorator.ts
+++ b/src/games/presentation/decorators/get-game-result-report-swagger.decorator.ts
@@ -75,7 +75,8 @@ export function ApiGetGameResultReport() {
     ]),
     createSwaggerForbidden([
       {
-        description: '(회원) 다른 회원의 게임결과 리포트 조회 접근제한',
+        description:
+          '유저가 다른유저의 게임결과 리포트 조회할 경우 & 비회원이 유저의 게임결과 리포트 조회할 경우 접근제한',
         message: '해당 게임 결과 리포트에 접근할 수 없습니다.',
       },
     ]),

--- a/src/games/presentation/games.controller.spec.ts
+++ b/src/games/presentation/games.controller.spec.ts
@@ -500,6 +500,15 @@ describe('GamesController', () => {
 
           await expect(controller.getGameResultReport(param)).rejects.toThrow(NotFoundException);
         });
+
+        it('비회원이 회원의 게임 결과 리포트에 접근하면 ForbiddenException을 던진다.', async () => {
+          const param = createParamDto(7n);
+          gameSessionService.getGameResultReport.mockRejectedValue(
+            new ForbiddenException('해당 게임 결과 리포트에 접근할 수 없습니다.'),
+          );
+
+          await expect(controller.getGameResultReport(param)).rejects.toThrow(ForbiddenException);
+        });
       });
     });
   });

--- a/test/games/get-game-result-report.e2e-spec.ts
+++ b/test/games/get-game-result-report.e2e-spec.ts
@@ -412,6 +412,16 @@ describe('GET /api/games/:gameSessionId/reports (e2e)', () => {
       expect(body.message).toBe('존재하지 않는 게임 세션입니다.');
     });
 
+    it('비회원이 회원의 게임 결과 리포트를 조회하면 403 에러를 응답한다.', async () => {
+      const response = await request(app.getHttpServer())
+        .get(`/api/games/${savedMemberGameSessionId}/reports`)
+        .expect(403);
+
+      const body = response.body as ErrorResponse;
+      expect(body.success).toBe(false);
+      expect(body.message).toBe('해당 게임 결과 리포트에 접근할 수 없습니다.');
+    });
+
     it('다른 회원의 게임 결과 리포트를 조회하면 403 에러를 응답한다.', async () => {
       const prisma = new PrismaClient({ datasourceUrl: process.env.DATABASE_URL });
       const anotherUser = await prisma.user.create({


### PR DESCRIPTION
# 백엔드 PR

## 📋 변경 사항 요약

[피그마 코멘트](https://www.figma.com/design/O7UO2gGqVLedZOvoBTaO7S?node-id=1216-33870#1637640977) 요구사항을 반영하기 위해

조건 3개로 게임결과리포트 조회 접근제어 규칙을 세웠습니다.

- (조건1) 비회원은 다른 비회원의 게임결과 리포트를 볼 수 있다
- (조건2) 비회원은 회원의 게임결과 리포트를 볼 수 없다. - 403 에러발생
- (조건3) 회원은 다른 회원의 게임결과 리포트를 볼 수 없다 - 403 에러 발생
  - 회원은 비회원의 게임결과 리포트를 볼 수 있다.

이슈사항에서는 (조건2)가 403에러가 발생하지 않고, 조회가 되는 문제가 발생했고
GameSessionService로직의 조건문을 수정했습니다.

(조건1)을 명시한 이유는 비회원은 모두 user_id=null 이므로 구분을 할 수 없습니다.
비회원 게임결과는 public하므로 전체공개하도록 설계했습니다.

## 🔗 관련 Issue

Closes #66

## 🎯 변경 내용

- [x] getGameResultReport 조건문수정
- [x] 단위 테스트케이스 추가(service, controller)
- [x] e2e 테스트케이스 추가
- [x] 스웨거 403오류 description 수정

## 📌 추가 참고사항

> ### (1) 비회원은 회원(user_id=1)의 게임결과 데이터를 볼 수 없다.
- gameSessionId = 7

<img width="1029" height="563" alt="image" src="https://github.com/user-attachments/assets/44cdb507-8d6d-4dfb-a8f4-46cbb4d81be5" />

<br>

> ### (2) 회원(user_id=1)은 다른회원(user_id=2)의 게임결과 데이터를 볼 수 없다
- gameSessionId = 5

<img width="1032" height="568" alt="image" src="https://github.com/user-attachments/assets/900578a9-51e0-421e-8a44-29d5aa998354" />


<br>

> ### (3) 회원(user_id=1)은 자신의 게임결과 데이터를 볼 수 있다.
- gameSessionId = 7

<img width="1025" height="795" alt="image" src="https://github.com/user-attachments/assets/f782c829-b250-4ee9-ac17-ef58e6a35155" />


<br>

> ### (4) 비회원은 다른 비회원의 게임결과 데이터를 볼 수 있다.
- gameSessionId = 10
<img width="1021" height="756" alt="image" src="https://github.com/user-attachments/assets/25b528fb-3944-4b82-83a9-a10aa9e1f3d7" />

---

### 403 swagger 

<img width="1386" height="255" alt="image" src="https://github.com/user-attachments/assets/b2dedf19-377b-4022-9a96-ae6a6cbde38f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Game result reports now require user authentication; unauthenticated requests return 403 Forbidden status.
  * Non-owner users are now properly prevented from accessing other users' game result reports.

* **Tests**
  * Added comprehensive test coverage for access control restrictions on game result report retrieval across authenticated and unauthenticated user scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->