### PR TITLE
[게임] 게임스트림 pending 이슈수정 - x-accel-buffering no 헤더 추가

### DIFF
--- a/src/games/presentation/decorators/game-stream-swagger.decorator.ts
+++ b/src/games/presentation/decorators/game-stream-swagger.decorator.ts
@@ -26,6 +26,24 @@ export function ApiGameStream() {
     }),
     ApiOkResponse({
       description: 'SSE 이벤트 스트림 (text/event-stream)',
+      headers: {
+        'Content-Type': {
+          description: 'SSE 스트림 컨텐츠 타입',
+          schema: { type: 'string', example: 'text/event-stream' },
+        },
+        'Cache-Control': {
+          description: '캐시 비활성화',
+          schema: { type: 'string', example: 'no-cache' },
+        },
+        Connection: {
+          description: '연결 유지',
+          schema: { type: 'string', example: 'keep-alive' },
+        },
+        'X-Accel-Buffering': {
+          description: '리버스 프록시 버퍼링 비활성화',
+          schema: { type: 'string', example: 'no' },
+        },
+      },
       content: {
         'text/event-stream': {
           examples: {

--- a/src/games/presentation/games.controller.spec.ts
+++ b/src/games/presentation/games.controller.spec.ts
@@ -150,7 +150,7 @@ describe('GamesController', () => {
 
     beforeEach(() => {
       mockResponse = {
-        setHeader: jest.fn(),
+        set: jest.fn(),
         flushHeaders: jest.fn(),
         write: jest.fn(),
         end: jest.fn(),
@@ -169,7 +169,12 @@ describe('GamesController', () => {
         await controller.gameStream(query, mockRequest, mockResponse as Response);
 
         expect(gameStreamService.validateGameStreamParams).toHaveBeenCalledWith(query.categoryId);
-        expect(mockResponse.setHeader).toHaveBeenCalledWith('Content-Type', 'text/event-stream');
+        expect(mockResponse.set).toHaveBeenCalledWith({
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          Connection: 'keep-alive',
+          'X-Accel-Buffering': 'no',
+        });
         expect(mockResponse.flushHeaders).toHaveBeenCalled();
         expect(gameStreamService.createGameStream).toHaveBeenCalledWith(
           query.categoryId,

--- a/src/games/presentation/games.controller.ts
+++ b/src/games/presentation/games.controller.ts
@@ -80,6 +80,7 @@ export class GamesController {
     response.setHeader('Content-Type', 'text/event-stream');
     response.setHeader('Cache-Control', 'no-cache');
     response.setHeader('Connection', 'keep-alive');
+    response.setHeader('X-Accel-Buffering', 'no');
     response.flushHeaders();
 
     const disconnectSignal$ = new Subject<void>();

--- a/src/games/presentation/games.controller.ts
+++ b/src/games/presentation/games.controller.ts
@@ -77,10 +77,12 @@ export class GamesController {
   ): Promise<void> {
     await this.gameStreamService.validateGameStreamParams(query.categoryId);
 
-    response.setHeader('Content-Type', 'text/event-stream');
-    response.setHeader('Cache-Control', 'no-cache');
-    response.setHeader('Connection', 'keep-alive');
-    response.setHeader('X-Accel-Buffering', 'no');
+    response.set({
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    });
     response.flushHeaders();
 
     const disconnectSignal$ = new Subject<void>();


### PR DESCRIPTION
# 백엔드 PR

## 📋 변경 사항 요약

pending되는 이슈의 원인파악하기.

## 🔗 관련 Issue

Closes #68

## 🎯 변경 내용

- [x] `/api/games/stream` api의 응답헤더에 `X-Accel-Buffering: no` 헤더를 추가

---

배포환경 가이드를 보니 orvit 인프라구조를 보니 nginx 로 리버스프록시환경으로 구성되어있습니다.

배포시 앞단에 nginx 와 같은 리버스프록시 환경이 있다면 응답을 버퍼링을 하게됩니다.
SSE응답이 프록시에 쌓이다가 연결이 끊기거나 버퍼가 차면 한꺼번에 전달됩니다.

`X-Accel-Buffering: no` 헤더를 추가하여 리버스프록시 환경에서 발생할 수 있는 응답의 버퍼링을 비활화할 수 있습니다.


## 📌 추가 참고사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced API documentation for game streaming responses with detailed header specifications.

* **Refactor**
  * Streamlined header configuration in the game streaming endpoint for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->