### PR TITLE
[유저] 스탯 조회 시 평균 점수 제거, 백분위 응답 추가

### DIFF
--- a/src/users/application/service-dto/get-user-stats.service-dto.ts
+++ b/src/users/application/service-dto/get-user-stats.service-dto.ts
@@ -2,6 +2,6 @@ import { User } from '../../domain/users.entity';
 
 export interface GetUserStatsServiceResponseDto {
   user: User;
-  avgScore: bigint;
+  totalUserCount: number;
   ranking: number;
 }

--- a/src/users/application/users.facade.ts
+++ b/src/users/application/users.facade.ts
@@ -32,7 +32,8 @@ export class UsersFacade {
     return UserStats.from({
       nickname: userStatsSource.user.nickname,
       totalScore: userStatsSource.user.totalScore,
-      percentile: (userStatsSource.ranking / userStatsSource.totalUserCount) * 100,
+      percentile:
+        Math.floor((userStatsSource.ranking / userStatsSource.totalUserCount) * 1000) / 10,
       ranking: userStatsSource.ranking,
       tier: userStatsSource.user.tier,
       scoreDetail,

--- a/src/users/application/users.facade.ts
+++ b/src/users/application/users.facade.ts
@@ -32,7 +32,7 @@ export class UsersFacade {
     return UserStats.from({
       nickname: userStatsSource.user.nickname,
       totalScore: userStatsSource.user.totalScore,
-      averageScore: userStatsSource.avgScore,
+      percentile: (userStatsSource.ranking / userStatsSource.totalUserCount) * 100,
       ranking: userStatsSource.ranking,
       tier: userStatsSource.user.tier,
       scoreDetail,

--- a/src/users/application/users.service.spec.ts
+++ b/src/users/application/users.service.spec.ts
@@ -51,7 +51,7 @@ describe('UsersService', () => {
       updateRefreshToken: jest.fn(),
       findByIdWithTier: jest.fn(),
       isExistUser: jest.fn(),
-      getAverageScore: jest.fn(),
+      getTotalUserCount: jest.fn(),
       getRankingByScore: jest.fn(),
       incrementTotalScore: jest.fn(),
       updateTierId: jest.fn(),
@@ -145,7 +145,7 @@ describe('UsersService', () => {
     });
     beforeEach(() => {
       mockUsersRepository.findByIdWithTier.mockResolvedValue(mockUser);
-      mockUsersRepository.getAverageScore.mockResolvedValue(190294n);
+      mockUsersRepository.getTotalUserCount.mockResolvedValue(200);
       mockUsersRepository.getRankingByScore.mockResolvedValue(131);
     });
 
@@ -153,7 +153,7 @@ describe('UsersService', () => {
       await service.getUserStats(1n);
 
       expect(mockUsersRepository.findByIdWithTier).toHaveBeenCalledWith(1n);
-      expect(mockUsersRepository.getAverageScore).toHaveBeenCalled();
+      expect(mockUsersRepository.getTotalUserCount).toHaveBeenCalled();
     });
 
     it('유저가 없으면 NotFoundException을 던지는지 확인', async () => {
@@ -162,12 +162,12 @@ describe('UsersService', () => {
       await expect(service.getUserStats(999n)).rejects.toThrow(NotFoundException);
     });
 
-    it('조회된 유저와 평균 점수, 랭킹 정보를 반환하는지 확인', async () => {
+    it('조회된 유저와 전체 유저 수, 랭킹 정보를 반환하는지 확인', async () => {
       const result = await service.getUserStats(1n);
 
       expect(result.user.nickname).toBe('Jin Park');
       expect(result.user.totalScore).toBe(54610n);
-      expect(result.avgScore).toBe(190294n);
+      expect(result.totalUserCount).toBe(200);
       expect(result.ranking).toBe(131);
       expect(result.user.tier?.name).toBe('Master');
     });

--- a/src/users/application/users.service.ts
+++ b/src/users/application/users.service.ts
@@ -100,12 +100,12 @@ export class UsersService {
   }
 
   /**
-   * @description 유저의 랭킹, 티어, 총 점수, 카테고리 별 누적점수를 조회
+   * @description 유저의 랭킹, 티어, 총 점수, 전체 유저 수를 조회
    */
   async getUserStats(userId: bigint): Promise<GetUserStatsServiceResponseDto> {
-    const [user, avgScore] = await Promise.all([
+    const [user, totalUserCount] = await Promise.all([
       this.usersRepository.findByIdWithTier(userId),
-      this.usersRepository.getAverageScore(),
+      this.usersRepository.getTotalUserCount(),
     ]);
 
     if (!user) {
@@ -116,7 +116,7 @@ export class UsersService {
 
     return {
       user: User.from(user),
-      avgScore,
+      totalUserCount,
       ranking,
     };
   }

--- a/src/users/domain/user-stats.entity.ts
+++ b/src/users/domain/user-stats.entity.ts
@@ -7,7 +7,7 @@ export class UserStats {
   constructor(
     public readonly nickname: string,
     public readonly totalScore: bigint,
-    public readonly averageScore: bigint,
+    public readonly percentile: number,
     public readonly ranking: number,
     public readonly tier: Tier | null,
     public readonly scoreDetail: DifficultyScoreDetail[],
@@ -16,13 +16,13 @@ export class UserStats {
   static from(
     data: Pick<
       UserStats,
-      'nickname' | 'totalScore' | 'averageScore' | 'ranking' | 'tier' | 'scoreDetail'
+      'nickname' | 'totalScore' | 'percentile' | 'ranking' | 'tier' | 'scoreDetail'
     >,
   ): UserStats {
     return new UserStats(
       data.nickname,
       data.totalScore,
-      data.averageScore,
+      data.percentile,
       data.ranking,
       data.tier,
       data.scoreDetail,

--- a/src/users/domain/users.repository.interface.ts
+++ b/src/users/domain/users.repository.interface.ts
@@ -18,7 +18,7 @@ export interface IUsersRepository {
   updateRefreshToken(userId: bigint, refreshToken: string): Promise<User>;
   findByIdWithTier(userId: bigint): Promise<User | null>;
   isExistUser(userId: bigint): Promise<boolean>;
-  getAverageScore(): Promise<bigint>;
+  getTotalUserCount(): Promise<number>;
   getRankingByScore(totalScore: bigint): Promise<number>;
   incrementTotalScore(userId: bigint, scoreToAdd: bigint): Promise<IncrementTotalScoreMapper>;
   updateTierId(userId: bigint, tierId: number): Promise<void>;

--- a/src/users/infrastructure/users.repository.ts
+++ b/src/users/infrastructure/users.repository.ts
@@ -108,15 +108,10 @@ export class UsersRepositoryImpl implements IUsersRepository {
   }
 
   /**
-   * @description 전체 유저의 totalScore average 조회, 유저가 없을 경우 0 반환
+   * @description 전체 유저 수 조회
    */
-  async getAverageScore(): Promise<bigint> {
-    const result = await this.prisma.user.aggregate({
-      _avg: { totalScore: true },
-    });
-
-    const avgScore = result._avg.totalScore ?? 0;
-    return BigInt(Math.round(avgScore));
+  async getTotalUserCount(): Promise<number> {
+    return this.prisma.user.count();
   }
 
   /**

--- a/src/users/presentation/dto/get-user-stats.dto.ts
+++ b/src/users/presentation/dto/get-user-stats.dto.ts
@@ -77,7 +77,7 @@ export class GetUserStatsResponseDto {
 
   @ApiProperty({
     description: '백분위 (상위 N%)',
-    example: 3,
+    example: 65.6,
   })
   percentile: number;
 

--- a/src/users/presentation/dto/get-user-stats.dto.ts
+++ b/src/users/presentation/dto/get-user-stats.dto.ts
@@ -1,9 +1,10 @@
+import { BadRequestException } from '@nestjs/common';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty } from 'class-validator';
+
 import { plainToInstance, Transform } from 'class-transformer';
+import { IsNotEmpty } from 'class-validator';
 
 import { UserStats } from '../../domain/user-stats.entity';
-import { BadRequestException } from '@nestjs/common';
 
 export class GetUserStatsParamDto {
   @ApiProperty({
@@ -75,10 +76,10 @@ export class GetUserStatsResponseDto {
   totalScore: string;
 
   @ApiProperty({
-    description: '전체 유저 평균 점수 (BigInt 안정성을 위해 String)',
-    example: '190293',
+    description: '백분위 (상위 N%)',
+    example: 3,
   })
-  averageScore: string;
+  percentile: number;
 
   @ApiProperty({ description: '현재 랭킹', example: 131 })
   ranking: number;
@@ -100,7 +101,7 @@ export class GetUserStatsResponseDto {
     return plainToInstance(GetUserStatsResponseDto, {
       nickname: userStats.nickname,
       totalScore: userStats.totalScore.toString(),
-      averageScore: userStats.averageScore.toString(),
+      percentile: userStats.percentile,
       ranking: userStats.ranking,
       tier: userStats.tier
         ? { id: userStats.tier.id, name: userStats.tier.name, imageUrl: userStats.tier.imageUrl }

--- a/src/users/presentation/users.controller.spec.ts
+++ b/src/users/presentation/users.controller.spec.ts
@@ -254,7 +254,7 @@ describe('UsersController', () => {
     const mockUserStats = UserStats.from({
       nickname: 'Jin Park',
       totalScore: 54610n,
-      averageScore: 190293n,
+      percentile: 65.5,
       ranking: 131,
       tier: mockTier,
       scoreDetail: [
@@ -284,7 +284,7 @@ describe('UsersController', () => {
 
       expect(result.nickname).toBe('Jin Park');
       expect(result.totalScore).toBe('54610');
-      expect(result.averageScore).toBe('190293');
+      expect(result.percentile).toBe(65.5);
       expect(result.ranking).toBe(131);
     });
 

--- a/test/users/get-user-stats.e2e-spec.ts
+++ b/test/users/get-user-stats.e2e-spec.ts
@@ -77,8 +77,11 @@ describe('GET /api/users/:userId/stats (e2e)', () => {
     const response = await request(app.getHttpServer()).get('/api/users/1/stats').expect(200);
     const body = response.body as { data: GetUserStatsResponseDto } & ApiResponseDto;
 
+    // 전체 유저 181명(타겟 1 + 랭커 130 + 하위 50), 131등
+    // percentile = Math.floor((131 / 181) * 1000) / 10 = 72.3
     expect(body.data.totalScore).toBe('54610');
     expect(body.data.ranking).toBe(131);
+    expect(body.data.percentile).toBe(72.3);
 
     const hardMode = body.data.scoreDetail.find((detail) => detail.difficultyMode === 'Hard');
     expect(hardMode).toBeDefined();


### PR DESCRIPTION
# 백엔드 PR

## 📋 변경 사항 요약

<!-- PR의 목적을 간략히 설명 -->
- 유저 리포트 랭킹 컴포넌트 디자인 변경에 따라 기존 평균 점수 응답을 백분위 응답으로 수정합니다.

## 🔗 관련 Issue

Closes #69 

## 🎯 변경 내용

- [ ] stats 조회 API 응답에서 `averageScore` 제거
- [ ] stats 조회 API 응답에 백분위 `percentile` 필드 추가
   - `totalUserCount`(전체 유저 수)를 같이 조회해 소숫점 첫째자리 내림 처리를 위해 `percentile:
        Math.floor((userStatsSource.ranking / userStatsSource.totalUserCount) * 1000) / 10` 로 계산
- [ ] 관련된 테스트 코드 수정

## 📌 추가 참고사항
<img width="512" height="609" alt="image" src="https://github.com/user-attachments/assets/c4bac44e-86fa-45ba-a413-0da919d98798" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User statistics now display percentile (top N%) instead of average score for clearer relative performance.

* **Chores**
  * Backend now provides total user count (number) in responses and internal flows; related service and DTO shapes updated.

* **Tests**
  * Unit, controller, and E2E tests updated to expect percentile and total-user-count values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->