### PR TITLE
feat: 프론트엔드 운영도메인 cors허용에  추가

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ async function bootstrap() {
   app.setGlobalPrefix('api');
   app.useGlobalInterceptors(new ResponseInterceptor(app.get(Reflector)));
   app.enableCors({
-    origin: ['http://localhost:3000'],
+    origin: ['http://localhost:3000', 'https://orvit.net'],
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
     allowedHeaders: ['Content-Type', 'Authorization'],
     credentials: true,


### PR DESCRIPTION
# 백엔드 PR

## 📋 변경 사항 요약

운영도메인 https://orvit.net cors origin에 허용하도록 추가

## 🔗 관련 Issue

Closes #72

## 🎯 변경 내용

- [x] main.ts 의 cors에 프론트엔드 운영도메인 추가
## 📌 추가 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CORS configuration to allow requests from an additional external origin, enabling broader cross-origin resource access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->