### PR TITLE
[게임] 게임문제 생성이 빨라서 문제 풀기 어려운 이슈

### DIFF
--- a/src/games/application/game-stream.service.ts
+++ b/src/games/application/game-stream.service.ts
@@ -1,11 +1,5 @@
 import { Inject, Injectable, MessageEvent, NotFoundException } from '@nestjs/common';
-import { GAME_REPOSITORY, IGameRepository } from '../domain/games.repository.interface';
-import {
-  GAME_TIMER_DURATION,
-  GameDifficultyMode,
-  PROBLEM_INTERVAL_MAX,
-  PROBLEM_INTERVAL_MIN,
-} from '../domain/game.business-rules';
+
 import {
   concatMap,
   delay,
@@ -20,11 +14,19 @@ import {
   takeUntil,
   timer,
 } from 'rxjs';
+
 import {
   EndEventData,
   ProblemEventData,
   TimerEventData,
 } from '../domain/game-stream-events.interface';
+import {
+  GAME_TIMER_DURATION,
+  GameDifficultyMode,
+  PROBLEM_INTERVAL_MAX,
+  PROBLEM_INTERVAL_MIN,
+} from '../domain/game.business-rules';
+import { GAME_REPOSITORY, IGameRepository } from '../domain/games.repository.interface';
 
 @Injectable()
 export class GameStreamService {

--- a/src/games/domain/game.business-rules.ts
+++ b/src/games/domain/game.business-rules.ts
@@ -46,13 +46,18 @@ export const GUEST_MAX_VIEWABLE_PROBLEMS = 10;
 /** 문제 출제 최소 간격 (ms) */
 export const PROBLEM_INTERVAL_MIN = 2000;
 
+/** 마지막 문제 풀이를 위한 최소 보장 시간 (초) */
+export const MIN_TIME_FOR_LAST_PROBLEM = 5;
+
 /**
  * 문제 출제 최대 간격 (ms)
  *
- * - 실제 랜덤 범위: [PROBLEM_INTERVAL_MIN, PROBLEM_INTERVAL_MAX) → [2000ms, 2749ms]
- * - 20문제 * 최대 2749ms ≈ 54.98초로 마지막 문제 도착 후 최소 5초의 답변 여유 보장
+ * - 마지막 문제 도착 후 최소 {@link MIN_TIME_FOR_LAST_PROBLEM}초의 답변 여유를 보장합니다.
+ * - 계산: ({@link GAME_TIMER_DURATION} - {@link MIN_TIME_FOR_LAST_PROBLEM}) * 1000 / {@link MAX_PROBLEMS_PER_GAME}
+ * - 실제 랜덤 범위: [{@link PROBLEM_INTERVAL_MIN}, {@link PROBLEM_INTERVAL_MAX})
  */
-export const PROBLEM_INTERVAL_MAX = 2750;
+export const PROBLEM_INTERVAL_MAX =
+  ((GAME_TIMER_DURATION - MIN_TIME_FOR_LAST_PROBLEM) * 1000) / MAX_PROBLEMS_PER_GAME;
 
 /**
  * 게임 세션 히스토리 정렬 기준

--- a/src/games/domain/game.business-rules.ts
+++ b/src/games/domain/game.business-rules.ts
@@ -44,12 +44,15 @@ export const MAX_PROBLEMS_PER_GAME = 20;
 export const GUEST_MAX_VIEWABLE_PROBLEMS = 10;
 
 /** 문제 출제 최소 간격 (ms) */
-export const PROBLEM_INTERVAL_MIN = 1000;
+export const PROBLEM_INTERVAL_MIN = 2000;
 
-/** 문제 출제 최대 간격 (ms) - 게임 시간 내 전체 문제 전송을 보장하기 위해 여유분 포함 (2400ms) */
-export const PROBLEM_INTERVAL_MAX = Math.floor(
-  (GAME_TIMER_DURATION * 1000 * 0.8) / MAX_PROBLEMS_PER_GAME,
-);
+/**
+ * 문제 출제 최대 간격 (ms)
+ *
+ * - 실제 랜덤 범위: [PROBLEM_INTERVAL_MIN, PROBLEM_INTERVAL_MAX) → [2000ms, 2749ms]
+ * - 20문제 * 최대 2749ms ≈ 54.98초로 마지막 문제 도착 후 최소 5초의 답변 여유 보장
+ */
+export const PROBLEM_INTERVAL_MAX = 2750;
 
 /**
  * 게임 세션 히스토리 정렬 기준


### PR DESCRIPTION
# 백엔드 PR

## 📋 변경 사항 요약

문제 출제 이벤트(problem)에서
문제를 출제하는 최소시간과 최대시간을 변경했습니다.

- 최소시간: 1초 -> `2초`
- 최대시간: 2.4초 -> `2.75초`

## 🔗 관련 Issue

Closes #74

## 🎯 변경 내용

- [x] 문제출제의 최소시간/최대시간을 수정했습니다.

## 📌 추가 참고사항


> 문제 출제 최대시간 3초로 설정하지 않고 2.75초로 설정한 이유?

- 왜 3초가 아닌가?

문제를 생성하는 시간도 랜덤이기때문입니다. 최악의경우에는 20문제 모두 3초간격으로 하게되면 문제를 놓칠 수 있기 때문입니다.

<br>

- 왜 2.75초 인가?
 
최악의경우 20문제 2.75초 간격으로 문제 생성시 마지막문제를 5초내로 문제를 풀 수 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved problem-timing for more consistent gameplay: minimum delay between problems increased to 2 seconds.
  * Maximum delay logic adjusted to reserve a small guaranteed buffer near the end of each game, so the final problem timing is more reliable and pacing adapts to game length.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->